### PR TITLE
Modernize: dep bumps, edition 2024, release tooling, and test coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+## [Unreleased] - ReleaseDate
+
+## [1.0.2] - 2025-02-11
+
+### Changed
+- Baseline for the changelog; see the Git history for releases prior to this entry.
+
+<!-- next-url -->
+[Unreleased]: https://github.com/cesarferreira/robin/compare/1.0.2...HEAD
+[1.0.2]: https://github.com/cesarferreira/robin/releases/tag/1.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,34 +3,19 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,44 +28,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"
@@ -106,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -118,35 +103,25 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "pin-project-lite",
  "slab",
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -155,15 +130,14 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -172,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel",
  "async-io",
@@ -186,7 +160,6 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix",
- "tracing",
 ]
 
 [[package]]
@@ -202,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -215,29 +188,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -248,9 +199,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -265,54 +216,59 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
+name = "aws-lc-rs"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
-name = "bitflags"
-version = "2.8.0"
+name = "block2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -323,36 +279,33 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -362,9 +315,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -372,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -384,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -396,24 +349,42 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -427,15 +398,23 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "unicode-width 0.2.0",
- "windows-sys 0.59.0",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -443,6 +422,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -462,15 +451,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
+ "derive_more",
+ "document-features",
+ "mio",
  "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -487,73 +478,59 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "powerfmt",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
  "console",
  "shell-words",
  "tempfile",
- "thiserror",
  "zeroize",
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -561,10 +538,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.17"
+name = "document-features"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "encode_unicode"
@@ -583,15 +575,15 @@ dependencies = [
 
 [[package]]
 name = "endi"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -599,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -610,25 +602,25 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -637,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -647,9 +639,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -658,55 +656,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "fs_extra"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -717,28 +706,25 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-task",
- "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -753,52 +739,54 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
-]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -808,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -820,9 +808,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -832,35 +820,12 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -870,27 +835,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -900,93 +865,85 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.5.2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -996,103 +953,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1101,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1111,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1121,125 +1040,170 @@ dependencies = [
 
 [[package]]
 name = "inquire"
-version = "0.6.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crossterm",
  "dyn-clone",
- "lazy_static",
- "newline-converter",
- "thiserror",
+ "fuzzy-matcher",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "once_cell",
- "wasm-bindgen",
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "libc"
-version = "0.2.169"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "bitflags 2.8.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "js-sys"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.2"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce8f34f3717aa37177e723df6c1fc5fb02b2a1087374ea3fe0ea42316dc8f91"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
- "dirs-next",
- "objc-foundation",
- "objc_id",
+ "log",
+ "objc2",
+ "objc2-foundation",
  "time",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
+ "uuid",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -1257,53 +1221,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "mockito"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
 dependencies = [
  "assert-json-diff",
  "bytes",
  "colored",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "futures-core",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper",
  "hyper-util",
  "log",
+ "pin-project-lite",
  "rand",
  "regex",
  "serde_json",
@@ -1313,50 +1258,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
-name = "newline-converter"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.8.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "notify-rust"
-version = "4.11.4"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ae13fb6065b0865d2310dfa55ce319245052ed95fbbe2bc87c99962c58d73f"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
+ "futures-lite",
  "log",
  "mac-notification-sys",
  "serde",
@@ -1366,103 +1273,66 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
-name = "objc"
-version = "0.2.7"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "malloc_buf",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "block",
- "objc",
- "objc_id",
+ "bitflags",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
-name = "objc_id"
-version = "0.1.1"
+name = "objc2-encode"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
-]
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
-name = "object"
-version = "0.36.7"
+name = "objc2-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "memchr",
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl"
-version = "0.10.68"
+name = "once_cell_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
-dependencies = [
- "bitflags 2.8.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-stream"
@@ -1482,9 +1352,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1492,40 +1362,34 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -1534,23 +1398,31 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1561,65 +1433,132 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.38"
+name = "quinn"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1627,38 +1566,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.8.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1668,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1679,48 +1607,62 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls",
- "ipnet",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1731,8 +1673,6 @@ dependencies = [
  "clap",
  "colored",
  "dialoguer",
- "dirs",
- "fuzzy-matcher",
  "inquire",
  "mockito",
  "notify-rust",
@@ -1741,58 +1681,141 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
  "tokio",
  "tokio-test",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
+name = "rustc-hash"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 2.8.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "semver",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustix"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "base64",
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1803,12 +1826,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.8.0",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1816,28 +1839,44 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.217"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1846,21 +1885,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1881,21 +1921,21 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1903,23 +1943,40 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
+ "mio",
  "signal-hook",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -1929,40 +1986,31 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1971,10 +2019,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "syn"
-version = "2.0.96"
+name = "subtle"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1983,15 +2037,18 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2000,20 +2057,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2021,43 +2078,43 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.2.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89f5fb70d6f62381f5d9b2ba9008196150b40b75f3068eb24faeddf1c686871"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml",
+ "thiserror",
  "windows",
  "windows-version",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2066,66 +2123,79 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.43.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
- "backtrace",
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,20 +2203,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2155,12 +2225,10 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
 dependencies = [
- "async-stream",
- "bytes",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -2168,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2181,20 +2249,72 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
  "winnow",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -2204,9 +2324,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2215,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2226,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -2241,55 +2361,50 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "uds_windows"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.0"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -2304,10 +2419,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "uuid"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2320,54 +2451,47 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2375,34 +2499,53 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2422,6 +2565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,31 +2581,55 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.56.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2462,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.56.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2472,21 +2648,72 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2500,26 +2727,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2540,34 +2761,38 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
 name = "windows-version"
-version = "0.1.2"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12476c23a74725c539b24eae8bfc0dac4029c39cdb561d9f23616accd4ae26d"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
- "windows-targets 0.53.0",
+ "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2577,15 +2802,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2595,15 +2814,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2613,9 +2826,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2625,15 +2838,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2643,15 +2850,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2661,15 +2862,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2679,15 +2874,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2697,58 +2886,37 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -2756,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2768,13 +2936,12 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.3.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192a0d989036cd60a1e91a54c9851fb9ad5bd96125d41803eed79d2e2ef74bd7"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs",
  "async-io",
  "async-lock",
  "async-process",
@@ -2785,18 +2952,18 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-util",
+ "futures-lite",
  "hex",
- "nix",
+ "libc",
  "ordered-stream",
+ "rustix",
  "serde",
  "serde_repr",
- "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
+ "uuid",
+ "windows-sys 0.61.2",
  "winnow",
- "xdg-home",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -2804,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.3.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3685b5c81fce630efc3e143a4ded235b107f1b1cdf186c3f115529e5e5ae4265"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2819,31 +2986,29 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.1.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519629a3f80976d89c575895b05677cbc45eaf9f70d62a364d819ba646409cc8"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "static_assertions",
  "winnow",
  "zvariant",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2852,18 +3017,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2873,15 +3038,26 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2890,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2900,15 +3076,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "zvariant"
-version = "5.2.0"
+name = "zmij"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e6b9b5f1361de2d5e7d9fd1ee5f6f7fcb6060618a1f82f3472f58f2b8d4be9"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "static_assertions",
  "winnow",
  "zvariant_derive",
  "zvariant_utils",
@@ -2916,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.2.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573a8dd76961957108b10f7a45bac6ab1ea3e9b7fe01aff88325dc57bb8f5c8b"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2929,14 +3110,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.1.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd46446ea2a1f353bfda53e35f17633afa79f4fe290a611c94645c69fe96a50"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "static_assertions",
  "syn",
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1363,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-stream"
@@ -1583,6 +1619,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +1720,7 @@ dependencies = [
  "clap",
  "colored",
  "dialoguer",
+ "dirs",
  "inquire",
  "mockito",
  "notify-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ test-utils = []
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+dirs = "6.0"
 colored = "3.1"
 inquire = "0.9"
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,19 @@ path = "src/lib.rs"
 test-utils = []
 
 [dependencies]
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-colored = "2.0"
-inquire = "0.6"
-fuzzy-matcher = "0.3"
-dirs = "5.0"
+colored = "3.1"
+inquire = "0.9"
 anyhow = "1.0"
-thiserror = "1.0"
-regex = "1.10"
-notify-rust = "4.10"
-dialoguer = "0.11"
-reqwest = { version = "0.11", features = ["json"] }
+regex = "1.12"
+notify-rust = "4.18"
+dialoguer = "0.12"
+reqwest = { version = "0.13", features = ["json"] }
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-tempfile = "3.8"
-mockito = "1.2"
+tempfile = "3.27"
+mockito = "1.7"
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "robin_cli_tool"
 version = "1.0.2"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 authors = ["Cesar Ferreira <cesar.manuel.ferreira@gmail.com>"]
 description = "A CLI tool to run scripts for any project"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.PHONY: all build build-release install install-release clean test check fmt lint run demo release
+
+LEVEL ?= minor
+
+# Default target
+all: check build test
+
+# Build debug version
+build:
+	cargo build
+
+# Build release version
+build-release:
+	cargo build --release
+
+# Install debug binary to ~/.cargo/bin
+install:
+	CARGO_INCREMENTAL=0 cargo install --path . --locked --bins --debug --force
+
+# Install release binary to ~/.cargo/bin
+install-release:
+	CARGO_INCREMENTAL=0 cargo install --path . --locked --bins --force
+
+# Clean build artifacts
+clean:
+	cargo clean
+
+# Run tests (nextest for unit/integration, cargo for doctests)
+test:
+	cargo nextest run
+	cargo test --doc
+
+# Run clippy and check
+check:
+	cargo check
+	cargo clippy -- -D warnings
+
+# Format code
+fmt:
+	cargo fmt
+
+# Lint (check formatting)
+lint:
+	cargo fmt -- --check
+	cargo clippy -- -D warnings
+
+# Run with arguments (usage: make run ARGS="--help")
+run:
+	cargo run -- $(ARGS)
+
+# Quick demo
+demo: install
+	@echo "=== robin demo ==="
+	robin --help
+
+# Bump version, finalize CHANGELOG.md, tag, publish, and push (requires cargo-release)
+release:
+	cargo release $(LEVEL) --execute --no-confirm

--- a/README.md
+++ b/README.md
@@ -381,6 +381,20 @@ This will update:
 - Global npm packages
 - CocoaPods repositories
 
+## Update Notifications
+
+Robin checks [crates.io](https://crates.io/crates/robin_cli_tool) for newer
+releases and prints a short notice when your installed version is out of date:
+
+```
+➜ A new version of robin is available: 1.5.0 (you have 1.0.2).
+  Update with: cargo install robin_cli_tool
+```
+
+The check is throttled to at most once per day (the result is cached under your
+OS cache directory), so it never slows down day-to-day usage. To disable it
+entirely, set the `ROBIN_NO_UPDATE_CHECK` environment variable.
+
 ## License
 
 MIT © [Cesar Ferreira](http://cesarferreira.com)

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,17 @@
+sign-commit = false
+sign-tag = false
+publish = true
+push = true
+tag-name = "{{version}}"
+
+# Finalize CHANGELOG.md inside cargo-release's release commit.
+pre-release-hook = [
+  "python3",
+  "scripts/prepare_release.py",
+  "--release-version",
+  "{{version}}",
+  "--previous-version",
+  "{{prev_version}}",
+  "--release-date",
+  "{{date}}",
+]

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import OrderedDict
+from datetime import date
+from pathlib import Path
+
+VERSION_TAG_RE = re.compile(r"^\d+\.\d+\.\d+$")
+CONVENTIONAL_RE = re.compile(r"^(?P<type>[a-z]+)(\([^)]+\))?(?P<breaking>!)?: (?P<desc>.+)$")
+SKIP_SUBJECT_RE = re.compile(r"^chore: Release robin_cli_tool version \d+\.\d+\.\d+$")
+UNRELEASED_BLOCK_RE = re.compile(
+    r"(?ms)^## \[Unreleased\] - ReleaseDate\s*\n.*?(?=^## \[|^<!-- next-url -->|\Z)"
+)
+UNRELEASED_LINK_RE = re.compile(
+    r"(?m)^\[Unreleased\]: (?P<compare_prefix>.+?/compare/)\d+\.\d+\.\d+\.\.\.HEAD$"
+)
+
+CATEGORY_ORDER = ["Added", "Changed", "Fixed", "Documentation"]
+
+
+class ReleasePrepError(Exception):
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate Keep a Changelog notes under the Unreleased section."
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Repository root to inspect. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--changelog",
+        help="Changelog path to rewrite. Defaults to <repo>/CHANGELOG.md.",
+    )
+    parser.add_argument(
+        "--release-version",
+        help="Finalize the changelog for this released version instead of only refreshing Unreleased notes.",
+    )
+    parser.add_argument(
+        "--previous-version",
+        help="Previous released version used to update compare links when finalizing a release.",
+    )
+    parser.add_argument(
+        "--release-date",
+        help="Release date to stamp into the finalized changelog entry (defaults to today).",
+    )
+    return parser.parse_args()
+
+
+def run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ReleasePrepError(result.stderr.strip() or f"git {' '.join(args)} failed")
+    return result.stdout
+
+
+def latest_version_tag(repo: Path) -> str:
+    output = run_git(repo, "tag", "--list", "--sort=-creatordate")
+    for line in output.splitlines():
+        tag = line.strip()
+        if VERSION_TAG_RE.match(tag):
+            return tag
+    raise ReleasePrepError("No version tags found matching <major>.<minor>.<patch>")
+
+
+def commits_since_tag(repo: Path, tag: str) -> list[str]:
+    output = run_git(repo, "log", "--reverse", "--no-merges", "--format=%s", f"{tag}..HEAD")
+    subjects = []
+    for line in output.splitlines():
+        subject = line.strip()
+        if not subject or SKIP_SUBJECT_RE.match(subject):
+            continue
+        subjects.append(subject)
+    if not subjects:
+        raise ReleasePrepError("No commits found since last tag")
+    return subjects
+
+
+def categorize_subject(subject: str) -> tuple[str, str]:
+    match = CONVENTIONAL_RE.match(subject)
+    commit_type = None
+    description = subject
+    if match:
+        commit_type = match.group("type").lower()
+        description = match.group("desc").strip()
+
+    if commit_type in {"feat", "feature", "add"}:
+        category = "Added"
+    elif commit_type in {"fix", "bugfix"}:
+        category = "Fixed"
+    elif commit_type in {"docs", "doc"}:
+        category = "Documentation"
+    else:
+        category = "Changed"
+
+    if description and description[0].islower():
+        description = description[0].upper() + description[1:]
+
+    return category, description
+
+
+def build_release_notes(subjects: list[str]) -> str:
+    categorized: OrderedDict[str, list[str]] = OrderedDict(
+        (category, []) for category in CATEGORY_ORDER
+    )
+
+    for subject in subjects:
+        category, description = categorize_subject(subject)
+        categorized[category].append(description)
+
+    lines: list[str] = []
+    for category, entries in categorized.items():
+        if not entries:
+            continue
+        lines.append(f"### {category}")
+        for entry in entries:
+            lines.append(f"- {entry}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def rewrite_unreleased_section(changelog: str, release_notes: str) -> str:
+    replacement = f"## [Unreleased] - ReleaseDate\n\n{release_notes}\n\n"
+    updated, count = UNRELEASED_BLOCK_RE.subn(replacement, changelog, count=1)
+    if count != 1:
+        raise ReleasePrepError("Failed to locate the Unreleased section in CHANGELOG.md")
+    return updated
+
+
+def rewrite_release_section(
+    changelog: str,
+    release_notes: str,
+    release_version: str,
+    release_date: str,
+) -> str:
+    replacement = (
+        "## [Unreleased] - ReleaseDate\n\n"
+        f"## [{release_version}] - {release_date}\n\n"
+        f"{release_notes}\n\n"
+    )
+    updated, count = UNRELEASED_BLOCK_RE.subn(replacement, changelog, count=1)
+    if count != 1:
+        raise ReleasePrepError("Failed to locate the Unreleased section in CHANGELOG.md")
+    return updated
+
+
+def rewrite_release_links(changelog: str, previous_version: str, release_version: str) -> str:
+    unreleased_match = UNRELEASED_LINK_RE.search(changelog)
+    if not unreleased_match:
+        raise ReleasePrepError("Failed to locate the Unreleased compare link in CHANGELOG.md")
+
+    compare_prefix = unreleased_match.group("compare_prefix")
+    updated = UNRELEASED_LINK_RE.sub(
+        f"[Unreleased]: {compare_prefix}{release_version}...HEAD",
+        changelog,
+        count=1,
+    )
+
+    previous_release_link_re = re.compile(rf"(?m)^\[{re.escape(previous_version)}\]: .*$")
+    new_release_link = (
+        f"[{release_version}]: {compare_prefix}{previous_version}...{release_version}"
+    )
+    updated, count = previous_release_link_re.subn(
+        lambda match: f"{new_release_link}\n{match.group(0)}",
+        updated,
+        count=1,
+    )
+    if count != 1:
+        raise ReleasePrepError(
+            f"Failed to locate the compare link for previous version {previous_version}"
+        )
+
+    return updated
+
+
+def resolve_release_context(args: argparse.Namespace) -> tuple[str, str, str] | None:
+    release_version = args.release_version or os.environ.get("NEW_VERSION")
+    previous_version = args.previous_version or os.environ.get("PREV_VERSION")
+    release_date = args.release_date or os.environ.get("RELEASE_DATE") or date.today().isoformat()
+
+    if not release_version and not previous_version and not args.release_date:
+        return None
+
+    if not release_version or not previous_version:
+        raise ReleasePrepError(
+            "Release finalization requires both --release-version and --previous-version "
+            "(or NEW_VERSION and PREV_VERSION)."
+        )
+
+    return release_version, previous_version, release_date
+
+
+def is_dry_run() -> bool:
+    return os.environ.get("DRY_RUN", "").strip().lower() == "true"
+
+
+def main() -> int:
+    args = parse_args()
+    repo = Path(args.repo).resolve()
+    changelog_path = Path(args.changelog).resolve() if args.changelog else repo / "CHANGELOG.md"
+
+    try:
+        release_context = resolve_release_context(args)
+        if release_context and is_dry_run():
+            print(f"Dry run: leaving {changelog_path} unchanged")
+            return 0
+
+        tag = latest_version_tag(repo)
+        subjects = commits_since_tag(repo, tag)
+        release_notes = build_release_notes(subjects)
+        changelog = changelog_path.read_text(encoding="utf-8")
+
+        if release_context:
+            release_version, previous_version, release_date = release_context
+            updated = rewrite_release_section(
+                changelog,
+                release_notes,
+                release_version,
+                release_date,
+            )
+            updated = rewrite_release_links(updated, previous_version, release_version)
+        else:
+            updated = rewrite_unreleased_section(changelog, release_notes)
+
+        if updated != changelog:
+            changelog_path.write_text(updated, encoding="utf-8")
+    except ReleasePrepError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if release_context:
+        print(f"Finalized {changelog_path} for {release_context[0]} using {len(subjects)} commits since {tag}")
+    else:
+        print(f"Updated {changelog_path} using {len(subjects)} commits since {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -27,7 +27,7 @@ pub enum Commands {
         #[arg(long)]
         template: Option<String>,
     },
-    
+
     /// Add a new command
     Add {
         /// Command name
@@ -45,4 +45,4 @@ pub enum Commands {
     /// Run a script
     #[command(external_subcommand)]
     Run(Vec<String>),
-} 
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,3 @@
 mod commands;
 
-pub use commands::{Cli, Commands}; 
+pub use commands::{Cli, Commands};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,3 +1,3 @@
 mod robin_config;
 
-pub use robin_config::RobinConfig; 
+pub use robin_config::RobinConfig;

--- a/src/config/robin_config.rs
+++ b/src/config/robin_config.rs
@@ -1,9 +1,9 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use serde::{Deserialize, Serialize};
-use anyhow::{Context, Result};
-use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RobinConfig {
@@ -15,12 +15,14 @@ pub struct RobinConfig {
 impl RobinConfig {
     pub fn load(path: &Path) -> Result<Self> {
         if !path.exists() {
-            return Err(anyhow::anyhow!("No .robin.json found. Run 'robin init' first"));
+            return Err(anyhow::anyhow!(
+                "No .robin.json found. Run 'robin init' first"
+            ));
         }
 
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
-        
+
         let mut config: Self = serde_json::from_str(&content)
             .with_context(|| "The .robin.json file exists but contains malformed JSON. Please check the file format.")?;
 
@@ -40,7 +42,7 @@ impl RobinConfig {
             let full_path = base_dir.join(include_path);
             let included_config = Self::load(&full_path)
                 .with_context(|| format!("Failed to load included config: {}", include_path))?;
-            
+
             // Merge scripts from included config; existing keys take precedence.
             for (key, value) in included_config.scripts {
                 merged_scripts.entry(key).or_insert(value);
@@ -54,27 +56,36 @@ impl RobinConfig {
     }
 
     pub fn save(&self, path: &Path) -> Result<()> {
-        let content = serde_json::to_string_pretty(self)
-            .with_context(|| "Failed to serialize config")?;
-        
+        let content =
+            serde_json::to_string_pretty(self).with_context(|| "Failed to serialize config")?;
+
         fs::write(path, content)
             .with_context(|| format!("Failed to write config to: {}", path.display()))?;
-        
+
         Ok(())
     }
 
     pub fn create_template() -> Self {
         let mut scripts = HashMap::new();
         scripts.insert("clean".to_string(), Value::String("...".to_string()));
-        scripts.insert("deploy staging".to_string(), Value::String("echo 'ruby deploy tool --staging'".to_string()));
-        scripts.insert("deploy production".to_string(), Value::String("...".to_string()));
+        scripts.insert(
+            "deploy staging".to_string(),
+            Value::String("echo 'ruby deploy tool --staging'".to_string()),
+        );
+        scripts.insert(
+            "deploy production".to_string(),
+            Value::String("...".to_string()),
+        );
         scripts.insert("release beta".to_string(), Value::String("...".to_string()));
-        scripts.insert("release alpha".to_string(), Value::String("...".to_string()));
+        scripts.insert(
+            "release alpha".to_string(),
+            Value::String("...".to_string()),
+        );
         scripts.insert("release dev".to_string(), Value::String("...".to_string()));
 
-        Self { 
+        Self {
             include: Vec::new(),
-            scripts 
+            scripts,
         }
     }
-} 
+}

--- a/src/config/robin_config.rs
+++ b/src/config/robin_config.rs
@@ -41,11 +41,9 @@ impl RobinConfig {
             let included_config = Self::load(&full_path)
                 .with_context(|| format!("Failed to load included config: {}", include_path))?;
             
-            // Merge scripts from included config
+            // Merge scripts from included config; existing keys take precedence.
             for (key, value) in included_config.scripts {
-                if !merged_scripts.contains_key(&key) {
-                    merged_scripts.insert(key, value);
-                }
+                merged_scripts.entry(key).or_insert(value);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ pub use utils::{send_notification, split_command_and_args, replace_variables};
 pub use scripts::{run_script, list_commands, interactive_mode};
 
 use anyhow::{Context, Result, anyhow};
-use reqwest;
 
 #[cfg(not(feature = "test-utils"))]
 pub async fn fetch_template(template_name: &str) -> Result<RobinConfig> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,18 @@
 pub const CONFIG_FILE: &str = ".robin.json";
-const GITHUB_TEMPLATE_BASE: &str = "https://raw.githubusercontent.com/cesarferreira/robin/refs/heads/main/templates";
+const GITHUB_TEMPLATE_BASE: &str =
+    "https://raw.githubusercontent.com/cesarferreira/robin/refs/heads/main/templates";
 
 pub mod cli;
 pub mod config;
+pub mod scripts;
 pub mod tools;
 pub mod utils;
-pub mod scripts;
 
 pub use cli::{Cli, Commands};
 pub use config::RobinConfig;
+pub use scripts::{interactive_mode, list_commands, run_script};
 pub use tools::{check_environment, update_tools};
-pub use utils::{send_notification, split_command_and_args, replace_variables, check_for_update};
-pub use scripts::{run_script, list_commands, interactive_mode};
+pub use utils::{check_for_update, replace_variables, send_notification, split_command_and_args};
 
 use anyhow::{Context, Result, anyhow};
 
@@ -21,18 +22,19 @@ pub async fn fetch_template(template_name: &str) -> Result<RobinConfig> {
     let response = reqwest::get(&url)
         .await
         .with_context(|| format!("Failed to fetch template from: {}", url))?;
-    
+
     if !response.status().is_success() {
         return Err(anyhow!("Template '{}' not found", template_name));
     }
 
-    let content = response.text()
+    let content = response
+        .text()
         .await
         .with_context(|| "Failed to read template content")?;
-    
-    let config: RobinConfig = serde_json::from_str(&content)
-        .with_context(|| "Failed to parse template JSON")?;
-    
+
+    let config: RobinConfig =
+        serde_json::from_str(&content).with_context(|| "Failed to parse template JSON")?;
+
     Ok(config)
 }
 
@@ -40,6 +42,12 @@ pub async fn fetch_template(template_name: &str) -> Result<RobinConfig> {
 pub async fn fetch_template(_template_name: &str) -> Result<RobinConfig> {
     use std::collections::HashMap;
     let mut scripts = HashMap::new();
-    scripts.insert("start".to_string(), serde_json::Value::String("npm start".to_string()));
-    Ok(RobinConfig { scripts, include: vec![] })
-} 
+    scripts.insert(
+        "start".to_string(),
+        serde_json::Value::String("npm start".to_string()),
+    );
+    Ok(RobinConfig {
+        scripts,
+        include: vec![],
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod scripts;
 pub use cli::{Cli, Commands};
 pub use config::RobinConfig;
 pub use tools::{check_environment, update_tools};
-pub use utils::{send_notification, split_command_and_args, replace_variables};
+pub use utils::{send_notification, split_command_and_args, replace_variables, check_for_update};
 pub use scripts::{run_script, list_commands, interactive_mode};
 
 use anyhow::{Context, Result, anyhow};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,36 @@
-use std::path::PathBuf;
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use colored::*;
 use dialoguer::Confirm;
+use std::path::PathBuf;
 
 use robin::{
-    Cli, Commands,
-    RobinConfig,
-    check_environment, update_tools,
-    send_notification, split_command_and_args, replace_variables,
-    run_script, list_commands, interactive_mode,
-    check_for_update,
-    CONFIG_FILE
+    CONFIG_FILE, Cli, Commands, RobinConfig, check_environment, check_for_update, interactive_mode,
+    list_commands, replace_variables, run_script, send_notification, split_command_and_args,
+    update_tools,
 };
 
-const GITHUB_TEMPLATE_BASE: &str = "https://raw.githubusercontent.com/cesarferreira/robin/refs/heads/main/templates";
+const GITHUB_TEMPLATE_BASE: &str =
+    "https://raw.githubusercontent.com/cesarferreira/robin/refs/heads/main/templates";
 
 async fn fetch_template(template_name: &str) -> Result<RobinConfig> {
     let url = format!("{}/{}.json", GITHUB_TEMPLATE_BASE, template_name);
     let response = reqwest::get(&url)
         .await
         .with_context(|| format!("Failed to fetch template from: {}", url))?;
-    
+
     if !response.status().is_success() {
         return Err(anyhow!("Template '{}' not found", template_name));
     }
 
-    let content = response.text()
+    let content = response
+        .text()
         .await
         .with_context(|| "Failed to read template content")?;
-    
-    let config: RobinConfig = serde_json::from_str(&content)
-        .with_context(|| "Failed to parse template JSON")?;
-    
+
+    let config: RobinConfig =
+        serde_json::from_str(&content).with_context(|| "Failed to parse template JSON")?;
+
     Ok(config)
 }
 
@@ -56,7 +54,7 @@ async fn dispatch(cli: &Cli) -> Result<()> {
                     .with_prompt("Config file already exists. Do you want to override it?")
                     .default(false)
                     .interact()?;
-                
+
                 if !should_override {
                     println!("{}", "Operation cancelled.".yellow());
                     return Ok(());
@@ -87,7 +85,9 @@ async fn dispatch(cli: &Cli) -> Result<()> {
                 RobinConfig::create_template()
             };
 
-            config.scripts.insert(name.clone(), serde_json::Value::String(script.clone()));
+            config
+                .scripts
+                .insert(name.clone(), serde_json::Value::String(script.clone()));
             config.save(&config_path)?;
             println!("{} {}", "Added command:".green(), name);
         }
@@ -101,7 +101,12 @@ async fn dispatch(cli: &Cli) -> Result<()> {
                 let message = if success {
                     format!("All {} tools found ({:.1}s)", found, duration.as_secs_f32())
                 } else {
-                    format!("{} tools found, {} missing ({:.1}s)", found, missing, duration.as_secs_f32())
+                    format!(
+                        "{} tools found, {} missing ({:.1}s)",
+                        found,
+                        missing,
+                        duration.as_secs_f32()
+                    )
                 };
                 send_notification("Robin Doctor", &message, success)?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use colored::*;
-use serde_json;
 use dialoguer::Confirm;
-use reqwest;
 
 use robin::{
     Cli, Commands,
@@ -86,9 +84,10 @@ async fn main() -> Result<()> {
         }
 
         Some(Commands::Doctor) => {
-            let start_time = std::time::Instant::now();
-            let (success, found, missing, duration) = check_environment()?;
-            
+            let config = RobinConfig::load(&config_path)
+                .with_context(|| "No .robin.json found. Run 'robin init' first")?;
+            let (success, found, missing, duration) = check_environment(&config)?;
+
             if cli.notify {
                 let message = if success {
                     format!("All {} tools found ({:.1}s)", found, duration.as_secs_f32())
@@ -100,9 +99,11 @@ async fn main() -> Result<()> {
         }
 
         Some(Commands::DoctorUpdate) => {
+            let config = RobinConfig::load(&config_path)
+                .with_context(|| "No .robin.json found. Run 'robin init' first")?;
             let start_time = std::time::Instant::now();
-            let (success, updated_tools) = update_tools()?;
-            
+            let (success, _updated_tools) = update_tools(&config)?;
+
             if cli.notify {
                 let duration = start_time.elapsed();
                 let message = if success {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use robin::{
     check_environment, update_tools,
     send_notification, split_command_and_args, replace_variables,
     run_script, list_commands, interactive_mode,
+    check_for_update,
     CONFIG_FILE
 };
 
@@ -38,6 +39,14 @@ async fn fetch_template(template_name: &str) -> Result<RobinConfig> {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Run the requested command first, then surface any available update.
+    let outcome = dispatch(&cli).await;
+    check_for_update().await;
+    outcome
+}
+
+async fn dispatch(cli: &Cli) -> Result<()> {
     let config_path = PathBuf::from(CONFIG_FILE);
 
     match &cli.command {

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -1,3 +1,3 @@
 mod script_runner;
 
-pub use script_runner::{run_script, list_commands, interactive_mode}; 
+pub use script_runner::{interactive_mode, list_commands, run_script};

--- a/src/scripts/script_runner.rs
+++ b/src/scripts/script_runner.rs
@@ -1,5 +1,5 @@
 use std::process::Command;
-use std::path::PathBuf;
+use std::path::Path;
 use anyhow::{Result, Context, anyhow};
 use colored::*;
 use inquire::Select;
@@ -81,7 +81,7 @@ pub fn run_script(script: &serde_json::Value, notify: bool) -> Result<()> {
     }
 }
 
-pub fn list_commands(config_path: &PathBuf) -> Result<()> {
+pub fn list_commands(config_path: &Path) -> Result<()> {
     let config = RobinConfig::load(config_path)
         .with_context(|| "No .robin.json found. Run 'robin init' first")?;
 
@@ -116,7 +116,7 @@ pub fn list_commands(config_path: &PathBuf) -> Result<()> {
     Ok(())
 }
 
-pub fn interactive_mode(config_path: &PathBuf) -> Result<()> {
+pub fn interactive_mode(config_path: &Path) -> Result<()> {
     let config = RobinConfig::load(config_path)
         .with_context(|| "No .robin.json found. Run 'robin init' first")?;
 

--- a/src/scripts/script_runner.rs
+++ b/src/scripts/script_runner.rs
@@ -1,28 +1,24 @@
-use std::process::Command;
-use std::path::Path;
-use anyhow::{Result, Context, anyhow};
+use anyhow::{Context, Result, anyhow};
 use colored::*;
 use inquire::Select;
 use serde_json;
+use std::path::Path;
+use std::process::Command;
 
 use crate::config::RobinConfig;
 use crate::utils::send_notification;
 
 pub fn run_script(script: &serde_json::Value, notify: bool) -> Result<()> {
     let start_time = std::time::Instant::now();
-    
+
     match script {
         serde_json::Value::String(cmd) => {
             let status = if cfg!(target_os = "windows") {
-                Command::new("cmd")
-                    .args(["/C", cmd])
-                    .status()
+                Command::new("cmd").args(["/C", cmd]).status()
             } else {
-                Command::new("sh")
-                    .arg("-c")
-                    .arg(cmd)
-                    .status()
-            }.with_context(|| format!("Failed to execute script: {}", cmd))?;
+                Command::new("sh").arg("-c").arg(cmd).status()
+            }
+            .with_context(|| format!("Failed to execute script: {}", cmd))?;
 
             if notify {
                 let duration = start_time.elapsed();
@@ -32,10 +28,14 @@ pub fn run_script(script: &serde_json::Value, notify: bool) -> Result<()> {
                 } else {
                     "Failed".to_string()
                 };
-                
+
                 send_notification(
                     "Robin",
-                    &format!("Command '{}' {}", cmd.split_whitespace().next().unwrap_or(cmd), message),
+                    &format!(
+                        "Command '{}' {}",
+                        cmd.split_whitespace().next().unwrap_or(cmd),
+                        message
+                    ),
                     success,
                 )?;
             }
@@ -45,20 +45,16 @@ pub fn run_script(script: &serde_json::Value, notify: bool) -> Result<()> {
                 return Err(anyhow!("Script failed: {}", cmd));
             }
             Ok(())
-        },
+        }
         serde_json::Value::Array(commands) => {
             for cmd in commands {
                 if let Some(cmd_str) = cmd.as_str() {
                     let status = if cfg!(target_os = "windows") {
-                        Command::new("cmd")
-                            .args(["/C", cmd_str])
-                            .status()
+                        Command::new("cmd").args(["/C", cmd_str]).status()
                     } else {
-                        Command::new("sh")
-                            .arg("-c")
-                            .arg(cmd_str)
-                            .status()
-                    }.with_context(|| format!("Failed to execute script: {}", cmd_str))?;
+                        Command::new("sh").arg("-c").arg(cmd_str).status()
+                    }
+                    .with_context(|| format!("Failed to execute script: {}", cmd_str))?;
 
                     if !status.success() {
                         println!("{}", format!("Script failed: {}", cmd_str).red());
@@ -71,13 +67,18 @@ pub fn run_script(script: &serde_json::Value, notify: bool) -> Result<()> {
                 let duration = start_time.elapsed();
                 send_notification(
                     "Robin",
-                    &format!("Command sequence completed in {:.1}s", duration.as_secs_f32()),
+                    &format!(
+                        "Command sequence completed in {:.1}s",
+                        duration.as_secs_f32()
+                    ),
                     true,
                 )?;
             }
             Ok(())
-        },
-        _ => Err(anyhow!("Invalid script type: must be string or array of strings")),
+        }
+        _ => Err(anyhow!(
+            "Invalid script type: must be string or array of strings"
+        )),
     }
 }
 
@@ -86,7 +87,9 @@ pub fn list_commands(config_path: &Path) -> Result<()> {
         .with_context(|| "No .robin.json found. Run 'robin init' first")?;
 
     // Find the longest command name for padding
-    let max_len = config.scripts.keys()
+    let max_len = config
+        .scripts
+        .keys()
         .map(|name| name.len())
         .max()
         .unwrap_or(0);
@@ -99,7 +102,7 @@ pub fn list_commands(config_path: &Path) -> Result<()> {
         match script {
             serde_json::Value::String(cmd) => {
                 println!("==> {:<width$} # {}", name.blue(), cmd, width = max_len);
-            },
+            }
             serde_json::Value::Array(commands) => {
                 println!("==> {:<width$} # [", name.blue(), width = max_len);
                 for cmd in commands {
@@ -108,8 +111,12 @@ pub fn list_commands(config_path: &Path) -> Result<()> {
                     }
                 }
                 println!("     ]");
-            },
-            _ => println!("==> {:<width$} # <invalid script type>", name.blue(), width = max_len),
+            }
+            _ => println!(
+                "==> {:<width$} # <invalid script type>",
+                name.blue(),
+                width = max_len
+            ),
         }
     }
 
@@ -132,4 +139,4 @@ pub fn interactive_mode(config_path: &Path) -> Result<()> {
     }
 
     Ok(())
-} 
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,3 +1,3 @@
 mod required_tools;
 
-pub use required_tools::{check_environment, update_tools}; 
+pub use required_tools::{check_environment, update_tools};

--- a/src/tools/required_tools.rs
+++ b/src/tools/required_tools.rs
@@ -99,17 +99,32 @@ pub const KNOWN_TOOLS: &[RequiredTool] = &[
 
 fn check_script_contains(script: &serde_json::Value, pattern: &str) -> bool {
     match script {
-        serde_json::Value::String(cmd) => cmd.contains(pattern),
+        serde_json::Value::String(cmd) => command_uses(cmd, pattern),
         serde_json::Value::Array(commands) => {
             commands.iter().any(|cmd| {
-                cmd.as_str().map_or(false, |s| s.contains(pattern))
+                cmd.as_str().is_some_and(|s| command_uses(s, pattern))
             })
         },
         _ => false,
     }
 }
 
-fn detect_required_tools(config: &RobinConfig) -> Vec<&'static RequiredTool> {
+/// Returns true when `pattern` (an invocation prefix such as `"go "`) appears
+/// in `cmd` at a command boundary — i.e. at the start of the string or right
+/// after whitespace or a shell separator. This prevents false positives like
+/// `"cargo build"` matching the Go pattern `"go "` because of the trailing
+/// `go` in `cargo`.
+fn command_uses(cmd: &str, pattern: &str) -> bool {
+    cmd.match_indices(pattern).any(|(idx, _)| {
+        idx == 0
+            || cmd[..idx]
+                .chars()
+                .next_back()
+                .is_some_and(|prev| prev.is_whitespace() || matches!(prev, ';' | '&' | '|' | '('))
+    })
+}
+
+pub fn detect_required_tools(config: &RobinConfig) -> Vec<&'static RequiredTool> {
     KNOWN_TOOLS
         .iter()
         .filter(|tool| {
@@ -120,20 +135,16 @@ fn detect_required_tools(config: &RobinConfig) -> Vec<&'static RequiredTool> {
         .collect()
 }
 
-pub fn check_environment() -> Result<(bool, usize, usize, std::time::Duration)> {
+pub fn check_environment(config: &RobinConfig) -> Result<(bool, usize, usize, std::time::Duration)> {
     let start_time = std::time::Instant::now();
     let mut all_checks_passed = true;
     let mut found_tools = 0;
     let mut missing_tools = 0;
 
-    let config_path = std::path::PathBuf::from(crate::CONFIG_FILE);
-    let config = RobinConfig::load(&config_path)
-        .with_context(|| "No .robin.json found. Run 'robin init' first")?;
-
     println!("🔍 Checking development environment...\n");
 
     // Check Required Tools
-    let required_tools = detect_required_tools(&config);
+    let required_tools = detect_required_tools(config);
     if !required_tools.is_empty() {
         println!("📦 Required Tools:");
         for tool in &required_tools {
@@ -205,12 +216,8 @@ pub fn check_environment() -> Result<(bool, usize, usize, std::time::Duration)> 
     Ok((all_checks_passed, found_tools, missing_tools, duration))
 }
 
-pub fn update_tools() -> Result<(bool, Vec<String>)> {
-    let config_path = std::path::PathBuf::from(crate::CONFIG_FILE);
-    let config = RobinConfig::load(&config_path)
-        .with_context(|| "No .robin.json found. Run 'robin init' first")?;
-
-    let required_tools = detect_required_tools(&config);
+pub fn update_tools(config: &RobinConfig) -> Result<(bool, Vec<String>)> {
+    let required_tools = detect_required_tools(config);
     let mut updated_tools = Vec::new();
     let mut all_success = true;
 
@@ -258,16 +265,17 @@ pub fn update_tools() -> Result<(bool, Vec<String>)> {
                     }
                 }
             },
-            "CocoaPods" => {
-                if cfg!(target_os = "macos") && Command::new("pod").arg("--version").output().is_ok() {
-                    println!("Updating CocoaPods repos...");
-                    if !run_update_command("pod", &["repo", "update"])? {
-                        all_success = false;
-                    } else {
-                        updated_tools.push("CocoaPods".to_string());
-                    }
+            "CocoaPods"
+                if cfg!(target_os = "macos")
+                    && Command::new("pod").arg("--version").output().is_ok() =>
+            {
+                println!("Updating CocoaPods repos...");
+                if !run_update_command("pod", &["repo", "update"])? {
+                    all_success = false;
+                } else {
+                    updated_tools.push("CocoaPods".to_string());
                 }
-            },
+            }
             _ => {}
         }
     }
@@ -291,4 +299,101 @@ fn run_update_command(cmd: &str, args: &[&str]) -> Result<bool> {
         println!("❌ {} update failed", cmd);
     }
     Ok(status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+    use std::collections::HashMap;
+
+    fn config_with(scripts: &[(&str, Value)]) -> RobinConfig {
+        let mut map = HashMap::new();
+        for (name, script) in scripts {
+            map.insert((*name).to_string(), script.clone());
+        }
+        RobinConfig { include: vec![], scripts: map }
+    }
+
+    fn tool_names(tools: &[&'static RequiredTool]) -> Vec<&'static str> {
+        let mut names: Vec<_> = tools.iter().map(|t| t.name).collect();
+        names.sort_unstable();
+        names
+    }
+
+    #[test]
+    fn check_script_contains_matches_string() {
+        assert!(check_script_contains(&json!("cargo build --release"), "cargo "));
+        assert!(!check_script_contains(&json!("cargo build"), "npm "));
+    }
+
+    #[test]
+    fn check_script_contains_matches_any_array_element() {
+        let script = json!(["echo hi", "docker compose up"]);
+        assert!(check_script_contains(&script, "docker "));
+        assert!(!check_script_contains(&script, "gradle "));
+    }
+
+    #[test]
+    fn check_script_contains_ignores_non_string_types() {
+        assert!(!check_script_contains(&json!(42), "cargo "));
+        assert!(!check_script_contains(&json!([1, 2, 3]), "cargo "));
+    }
+
+    #[test]
+    fn detect_required_tools_finds_only_referenced_tools() {
+        let config = config_with(&[
+            ("build", json!("cargo build")),
+            ("web", json!("npm run dev")),
+        ]);
+        assert_eq!(tool_names(&detect_required_tools(&config)), vec!["Cargo", "Node.js"]);
+    }
+
+    #[test]
+    fn detect_required_tools_deduplicates_across_scripts() {
+        // Two scripts both reference cargo; the tool must appear only once.
+        let config = config_with(&[
+            ("build", json!("cargo build")),
+            ("test", json!("cargo test")),
+        ]);
+        let tools = detect_required_tools(&config);
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "Cargo");
+    }
+
+    #[test]
+    fn detect_required_tools_matches_inside_arrays() {
+        let config = config_with(&[("release", json!(["cargo build", "docker push img"]))]);
+        assert_eq!(tool_names(&detect_required_tools(&config)), vec!["Cargo", "Docker"]);
+    }
+
+    #[test]
+    fn detect_required_tools_returns_empty_when_nothing_matches() {
+        let config = config_with(&[("hello", json!("echo hello world"))]);
+        assert!(detect_required_tools(&config).is_empty());
+    }
+
+    #[test]
+    fn detect_required_tools_requires_trailing_space_boundary() {
+        // "gocardless" must not be mistaken for the Go toolchain ("go ").
+        let config = config_with(&[("pay", json!("gocardless charge"))]);
+        assert!(detect_required_tools(&config).is_empty());
+    }
+
+    #[test]
+    fn cargo_script_does_not_falsely_detect_go() {
+        // Regression: "cargo build" contains the substring "go " but must only
+        // detect Cargo, never the Go toolchain.
+        let config = config_with(&[("build", json!("cargo build --release"))]);
+        assert_eq!(tool_names(&detect_required_tools(&config)), vec!["Cargo"]);
+    }
+
+    #[test]
+    fn command_uses_respects_boundaries() {
+        assert!(command_uses("go build", "go "));
+        assert!(command_uses("cd svc && go test ./...", "go ")); // after "&& "
+        assert!(command_uses("npm run dev", "npm "));
+        assert!(!command_uses("cargo build", "go ")); // trailing "go" in cargo
+        assert!(!command_uses("gocardless pay", "go ")); // no boundary
+    }
 } 

--- a/src/tools/required_tools.rs
+++ b/src/tools/required_tools.rs
@@ -1,6 +1,6 @@
-use std::process::Command;
-use anyhow::{Result, Context};
 use crate::config::RobinConfig;
+use anyhow::{Context, Result};
+use std::process::Command;
 
 #[derive(Debug, PartialEq)]
 pub struct RequiredTool {
@@ -100,11 +100,9 @@ pub const KNOWN_TOOLS: &[RequiredTool] = &[
 fn check_script_contains(script: &serde_json::Value, pattern: &str) -> bool {
     match script {
         serde_json::Value::String(cmd) => command_uses(cmd, pattern),
-        serde_json::Value::Array(commands) => {
-            commands.iter().any(|cmd| {
-                cmd.as_str().is_some_and(|s| command_uses(s, pattern))
-            })
-        },
+        serde_json::Value::Array(commands) => commands
+            .iter()
+            .any(|cmd| cmd.as_str().is_some_and(|s| command_uses(s, pattern))),
         _ => false,
     }
 }
@@ -129,13 +127,17 @@ pub fn detect_required_tools(config: &RobinConfig) -> Vec<&'static RequiredTool>
         .iter()
         .filter(|tool| {
             config.scripts.values().any(|script| {
-                tool.patterns.iter().any(|&pattern| check_script_contains(script, pattern))
+                tool.patterns
+                    .iter()
+                    .any(|&pattern| check_script_contains(script, pattern))
             })
         })
         .collect()
 }
 
-pub fn check_environment(config: &RobinConfig) -> Result<(bool, usize, usize, std::time::Duration)> {
+pub fn check_environment(
+    config: &RobinConfig,
+) -> Result<(bool, usize, usize, std::time::Duration)> {
     let start_time = std::time::Instant::now();
     let mut all_checks_passed = true;
     let mut found_tools = 0;
@@ -166,10 +168,12 @@ pub fn check_environment(config: &RobinConfig) -> Result<(bool, usize, usize, st
 
     // Check Environment Variables if needed tools are detected
     let needs_android = required_tools.iter().any(|t| t.name == "Flutter");
-    let needs_java = needs_android || config.scripts.values().any(|s| 
-        check_script_contains(s, "java ") || check_script_contains(s, "gradle ")
-    );
-    
+    let needs_java = needs_android
+        || config
+            .scripts
+            .values()
+            .any(|s| check_script_contains(s, "java ") || check_script_contains(s, "gradle "));
+
     if needs_android || needs_java {
         println!("\n🔧 Environment Variables:");
         if needs_android {
@@ -195,7 +199,11 @@ pub fn check_environment(config: &RobinConfig) -> Result<(bool, usize, usize, st
     }
 
     // Check Git Configuration if git commands are used
-    if config.scripts.values().any(|s| check_script_contains(s, "git ")) {
+    if config
+        .scripts
+        .values()
+        .any(|s| check_script_contains(s, "git "))
+    {
         println!("\n🔐 Git Configuration:");
         for key in ["user.name", "user.email"].iter() {
             match Command::new("git").args(["config", key]).output() {
@@ -234,7 +242,7 @@ pub fn update_tools(config: &RobinConfig) -> Result<(bool, Vec<String>)> {
                         updated_tools.push("npm packages".to_string());
                     }
                 }
-            },
+            }
             "Ruby" | "Fastlane" => {
                 if Command::new("gem").arg("--version").output().is_ok() {
                     println!("Updating Fastlane...");
@@ -244,7 +252,7 @@ pub fn update_tools(config: &RobinConfig) -> Result<(bool, Vec<String>)> {
                         updated_tools.push("Fastlane".to_string());
                     }
                 }
-            },
+            }
             "Flutter" => {
                 if Command::new("flutter").arg("--version").output().is_ok() {
                     println!("Updating Flutter...");
@@ -254,7 +262,7 @@ pub fn update_tools(config: &RobinConfig) -> Result<(bool, Vec<String>)> {
                         updated_tools.push("Flutter".to_string());
                     }
                 }
-            },
+            }
             "Cargo" => {
                 if Command::new("rustup").arg("--version").output().is_ok() {
                     println!("Updating Rust toolchain...");
@@ -264,7 +272,7 @@ pub fn update_tools(config: &RobinConfig) -> Result<(bool, Vec<String>)> {
                         updated_tools.push("Rust".to_string());
                     }
                 }
-            },
+            }
             "CocoaPods"
                 if cfg!(target_os = "macos")
                     && Command::new("pod").arg("--version").output().is_ok() =>
@@ -312,7 +320,10 @@ mod tests {
         for (name, script) in scripts {
             map.insert((*name).to_string(), script.clone());
         }
-        RobinConfig { include: vec![], scripts: map }
+        RobinConfig {
+            include: vec![],
+            scripts: map,
+        }
     }
 
     fn tool_names(tools: &[&'static RequiredTool]) -> Vec<&'static str> {
@@ -323,7 +334,10 @@ mod tests {
 
     #[test]
     fn check_script_contains_matches_string() {
-        assert!(check_script_contains(&json!("cargo build --release"), "cargo "));
+        assert!(check_script_contains(
+            &json!("cargo build --release"),
+            "cargo "
+        ));
         assert!(!check_script_contains(&json!("cargo build"), "npm "));
     }
 
@@ -346,7 +360,10 @@ mod tests {
             ("build", json!("cargo build")),
             ("web", json!("npm run dev")),
         ]);
-        assert_eq!(tool_names(&detect_required_tools(&config)), vec!["Cargo", "Node.js"]);
+        assert_eq!(
+            tool_names(&detect_required_tools(&config)),
+            vec!["Cargo", "Node.js"]
+        );
     }
 
     #[test]
@@ -364,7 +381,10 @@ mod tests {
     #[test]
     fn detect_required_tools_matches_inside_arrays() {
         let config = config_with(&[("release", json!(["cargo build", "docker push img"]))]);
-        assert_eq!(tool_names(&detect_required_tools(&config)), vec!["Cargo", "Docker"]);
+        assert_eq!(
+            tool_names(&detect_required_tools(&config)),
+            vec!["Cargo", "Docker"]
+        );
     }
 
     #[test]
@@ -396,4 +416,4 @@ mod tests {
         assert!(!command_uses("cargo build", "go ")); // trailing "go" in cargo
         assert!(!command_uses("gocardless pay", "go ")); // no boundary
     }
-} 
+}

--- a/src/utils/command_utils.rs
+++ b/src/utils/command_utils.rs
@@ -30,7 +30,7 @@ pub fn replace_variables(script: &serde_json::Value, args: &[String]) -> Result<
         serde_json::Value::String(cmd) => {
             let replaced = replace_variables_in_string(cmd, args)?;
             Ok(serde_json::Value::String(replaced))
-        },
+        }
         serde_json::Value::Array(commands) => {
             let mut replaced_commands = Vec::new();
             for cmd in commands {
@@ -42,7 +42,7 @@ pub fn replace_variables(script: &serde_json::Value, args: &[String]) -> Result<
                 }
             }
             Ok(serde_json::Value::Array(replaced_commands))
-        },
+        }
         _ => Ok(script.clone()),
     }
 }
@@ -50,7 +50,7 @@ pub fn replace_variables(script: &serde_json::Value, args: &[String]) -> Result<
 fn replace_variables_in_string(script: &str, args: &[String]) -> Result<String> {
     let var_regex = Regex::new(r"\{\{(\w+)(?:=([^}]+|\[[^\]]+\]))?\}\}").unwrap();
     let mut result = script.to_string();
-    
+
     for capture in var_regex.captures_iter(script) {
         let full_match = &capture[0];
         let var_name = &capture[1];
@@ -58,32 +58,42 @@ fn replace_variables_in_string(script: &str, args: &[String]) -> Result<String> 
         let var_pattern = format!("--{}=", var_name);
 
         if default_or_enum.starts_with('[') && default_or_enum.ends_with(']') {
-            let allowed_values: Vec<&str> = default_or_enum[1..default_or_enum.len()-1]
+            let allowed_values: Vec<&str> = default_or_enum[1..default_or_enum.len() - 1]
                 .split(',')
                 .map(|s| s.trim())
                 .collect();
-            
-            let value = args.iter()
+
+            let value = args
+                .iter()
                 .find(|arg| arg.starts_with(&var_pattern))
                 .map(|arg| arg.trim_start_matches(&var_pattern))
                 .ok_or_else(|| anyhow!("Missing required variable: {}", var_name))?;
 
             if !allowed_values.contains(&value) {
-                return Err(anyhow!("Value '{}' for {} must be one of: {}", 
-                    value, var_name, allowed_values.join(", ")));
+                return Err(anyhow!(
+                    "Value '{}' for {} must be one of: {}",
+                    value,
+                    var_name,
+                    allowed_values.join(", ")
+                ));
             }
-            
+
             result = result.replace(full_match, value);
         } else {
-            let value = args.iter()
+            let value = args
+                .iter()
                 .find(|arg| arg.starts_with(&var_pattern))
                 .map(|arg| arg.trim_start_matches(&var_pattern))
-                .or(if default_or_enum.is_empty() { None } else { Some(default_or_enum) })
+                .or(if default_or_enum.is_empty() {
+                    None
+                } else {
+                    Some(default_or_enum)
+                })
                 .ok_or_else(|| anyhow!("Missing required variable: {}", var_name))?;
 
             result = result.replace(full_match, value);
         }
     }
-    
+
     Ok(result)
-} 
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,7 @@
-mod notifications;
 mod command_utils;
+mod notifications;
 mod update_check;
 
+pub use command_utils::{replace_variables, split_command_and_args};
 pub use notifications::send_notification;
-pub use command_utils::{split_command_and_args, replace_variables};
-pub use update_check::check_for_update; 
+pub use update_check::check_for_update;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,7 @@
 mod notifications;
 mod command_utils;
+mod update_check;
 
 pub use notifications::send_notification;
-pub use command_utils::{split_command_and_args, replace_variables}; 
+pub use command_utils::{split_command_and_args, replace_variables};
+pub use update_check::check_for_update; 

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -1,6 +1,6 @@
-use std::process::Command;
 use anyhow::Result;
 use notify_rust::Notification;
+use std::process::Command;
 
 pub fn send_notification(title: &str, message: &str, success: bool) -> Result<()> {
     if cfg!(target_os = "windows") {
@@ -16,10 +16,14 @@ pub fn send_notification(title: &str, message: &str, success: bool) -> Result<()
     } else {
         // Use notify-rust for Unix-like systems (Linux and macOS)
         let mut notification = Notification::new();
-        
+
         notification
             .summary(title)
-            .body(&format!("{} {}", if success { "✅" } else { "❌" }, message))
+            .body(&format!(
+                "{} {}",
+                if success { "✅" } else { "❌" },
+                message
+            ))
             .timeout(5000); // 5 seconds
 
         // Set appropriate icon based on the platform
@@ -32,4 +36,4 @@ pub fn send_notification(title: &str, message: &str, success: bool) -> Result<()
         notification.show()?;
     }
     Ok(())
-} 
+}

--- a/src/utils/update_check.rs
+++ b/src/utils/update_check.rs
@@ -1,0 +1,189 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use colored::*;
+use serde::{Deserialize, Serialize};
+
+const PKG_NAME: &str = "robin_cli_tool";
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// How long to wait between network checks. We hit crates.io at most once a day.
+const CHECK_INTERVAL_SECS: u64 = 60 * 60 * 24;
+/// Keep the network check snappy so it never noticeably delays the CLI.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct UpdateCache {
+    last_check: u64,
+    latest_version: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CratesResponse {
+    #[serde(rename = "crate")]
+    krate: CrateInfo,
+}
+
+#[derive(Deserialize)]
+struct CrateInfo {
+    max_stable_version: Option<String>,
+    newest_version: Option<String>,
+}
+
+/// Best-effort, throttled "new version available" check against crates.io.
+///
+/// It never fails the caller and never blocks for long: the network is queried
+/// at most once per [`CHECK_INTERVAL_SECS`] (the result is cached on disk), and
+/// a short notice is printed to stderr whenever the cached latest version is
+/// newer than the running one. Set `ROBIN_NO_UPDATE_CHECK` to disable it.
+pub async fn check_for_update() {
+    if std::env::var_os("ROBIN_NO_UPDATE_CHECK").is_some() {
+        return;
+    }
+    // Swallow every error: an update check must never break a real command.
+    let _ = run_check().await;
+}
+
+async fn run_check() -> Result<()> {
+    let now = unix_now();
+    let path = cache_path().context("no cache directory available")?;
+    let mut cache = read_cache(&path);
+
+    // Only touch the network when the cached result is stale.
+    if now.saturating_sub(cache.last_check) >= CHECK_INTERVAL_SECS {
+        let latest = fetch_latest().await;
+        // Record the attempt either way so we don't retry on every invocation;
+        // keep any previously known version if the request failed.
+        cache.last_check = now;
+        if let Some(latest) = latest {
+            cache.latest_version = Some(latest);
+        }
+        let _ = write_cache(&path, &cache);
+    }
+
+    if let Some(latest) = &cache.latest_version {
+        if is_newer(latest, CURRENT_VERSION) {
+            print_notice(latest);
+        }
+    }
+    Ok(())
+}
+
+fn print_notice(latest: &str) {
+    eprintln!(
+        "\n{} A new version of robin is available: {} (you have {}).\n  Update with: {}",
+        "➜".yellow().bold(),
+        latest.green().bold(),
+        CURRENT_VERSION,
+        format!("cargo install {PKG_NAME}").cyan(),
+    );
+}
+
+async fn fetch_latest() -> Option<String> {
+    let url = format!("https://crates.io/api/v1/crates/{PKG_NAME}");
+    let client = reqwest::Client::builder()
+        .user_agent(concat!(
+            "robin/",
+            env!("CARGO_PKG_VERSION"),
+            " (update-check; https://github.com/cesarferreira/robin)"
+        ))
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .ok()?;
+
+    let resp = client.get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    let body: CratesResponse = resp.json().await.ok()?;
+    body.krate.max_stable_version.or(body.krate.newest_version)
+}
+
+fn cache_path() -> Option<PathBuf> {
+    Some(dirs::cache_dir()?.join("robin").join("update_check.json"))
+}
+
+fn read_cache(path: &Path) -> UpdateCache {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn write_cache(path: &Path, cache: &UpdateCache) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_string(cache)?)?;
+    Ok(())
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Compares dotted numeric versions numerically (so `1.0.10` > `1.0.9`). Any
+/// parse failure yields `false`, so an unexpected version string never nags.
+fn is_newer(candidate: &str, current: &str) -> bool {
+    match (parse_version(candidate), parse_version(current)) {
+        (Some(a), Some(b)) => a > b,
+        _ => false,
+    }
+}
+
+fn parse_version(v: &str) -> Option<(u64, u64, u64)> {
+    // Drop any pre-release/build suffix (e.g. "1.2.3-beta.1" -> "1.2.3").
+    let core = v.split(['-', '+']).next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_patch_minor_major() {
+        assert!(is_newer("1.0.3", "1.0.2"));
+        assert!(is_newer("1.1.0", "1.0.9"));
+        assert!(is_newer("2.0.0", "1.9.9"));
+    }
+
+    #[test]
+    fn same_or_older_is_not_newer() {
+        assert!(!is_newer("1.0.2", "1.0.2"));
+        assert!(!is_newer("1.0.1", "1.0.2"));
+        assert!(!is_newer("0.9.9", "1.0.0"));
+    }
+
+    #[test]
+    fn comparison_is_numeric_not_lexical() {
+        // "1.0.10" must beat "1.0.9" — a string compare would get this wrong.
+        assert!(is_newer("1.0.10", "1.0.9"));
+        assert!(!is_newer("1.0.9", "1.0.10"));
+    }
+
+    #[test]
+    fn prerelease_suffix_is_ignored() {
+        assert!(is_newer("1.0.3-beta.1", "1.0.2"));
+        assert!(!is_newer("1.0.2-rc.1", "1.0.2"));
+    }
+
+    #[test]
+    fn unparseable_versions_never_nag() {
+        assert!(!is_newer("not-a-version", "1.0.2"));
+        assert!(!is_newer("1.0", "1.0.2"));
+        assert!(!is_newer("1.0.2.3", "1.0.2"));
+    }
+}

--- a/tests/command_tests.rs
+++ b/tests/command_tests.rs
@@ -1,5 +1,3 @@
-mod common;
-
 use robin::utils::{split_command_and_args, replace_variables};
 use serde_json::Value;
 

--- a/tests/command_tests.rs
+++ b/tests/command_tests.rs
@@ -1,11 +1,15 @@
-use robin::utils::{split_command_and_args, replace_variables};
+use robin::utils::{replace_variables, split_command_and_args};
 use serde_json::Value;
 
 #[test]
 fn test_split_command_and_args() {
-    let args = vec!["command".to_string(), "--arg1=value1".to_string(), "--arg2=value2".to_string()];
+    let args = vec![
+        "command".to_string(),
+        "--arg1=value1".to_string(),
+        "--arg2=value2".to_string(),
+    ];
     let (command, var_args) = split_command_and_args(&args);
-    
+
     assert_eq!(command, "command");
     assert_eq!(var_args, vec!["--arg1=value1", "--arg2=value2"]);
 }
@@ -13,11 +17,8 @@ fn test_split_command_and_args() {
 #[test]
 fn test_replace_variables() {
     let script = Value::String("echo {{VAR1}} {{VAR2}}".to_string());
-    let args = vec![
-        "--VAR1=hello".to_string(),
-        "--VAR2=world".to_string()
-    ];
-    
+    let args = vec!["--VAR1=hello".to_string(), "--VAR2=world".to_string()];
+
     let result = replace_variables(&script, &args).unwrap();
     assert_eq!(result.as_str().unwrap(), "echo hello world");
 }
@@ -26,7 +27,7 @@ fn test_replace_variables() {
 fn test_replace_variables_with_defaults() {
     let script = Value::String("echo {{VAR1=hello}} {{VAR2=world}}".to_string());
     let args = vec![];
-    
+
     let result = replace_variables(&script, &args).unwrap();
     assert_eq!(result.as_str().unwrap(), "echo hello world");
 }
@@ -34,12 +35,12 @@ fn test_replace_variables_with_defaults() {
 #[test]
 fn test_replace_variables_with_enum_validation() {
     let script = Value::String("deploy {{env=[staging,prod]}}".to_string());
-    
+
     // Valid value
     let args = vec!["--env=staging".to_string()];
     let result = replace_variables(&script, &args).unwrap();
     assert_eq!(result.as_str().unwrap(), "deploy staging");
-    
+
     // Invalid value
     let args = vec!["--env=invalid".to_string()];
     assert!(replace_variables(&script, &args).is_err());
@@ -49,7 +50,7 @@ fn test_replace_variables_with_enum_validation() {
 fn test_replace_variables_with_array_commands() {
     let commands = vec![
         "echo {{VAR1=hello}}".to_string(),
-        "echo {{VAR2=world}}".to_string()
+        "echo {{VAR2=world}}".to_string(),
     ];
     let script = Value::Array(commands.into_iter().map(Value::String).collect());
     let args = vec![];
@@ -118,14 +119,20 @@ fn split_positional_after_first_flag_stays_with_args() {
 fn missing_required_variable_errors() {
     let script = Value::String("echo {{NAME}}".to_string());
     let err = replace_variables(&script, &[]).unwrap_err();
-    assert!(err.to_string().contains("Missing required variable"), "{err}");
+    assert!(
+        err.to_string().contains("Missing required variable"),
+        "{err}"
+    );
 }
 
 #[test]
 fn missing_enum_variable_errors() {
     let script = Value::String("deploy {{env=[staging,prod]}}".to_string());
     let err = replace_variables(&script, &[]).unwrap_err();
-    assert!(err.to_string().contains("Missing required variable"), "{err}");
+    assert!(
+        err.to_string().contains("Missing required variable"),
+        "{err}"
+    );
 }
 
 #[test]

--- a/tests/command_tests.rs
+++ b/tests/command_tests.rs
@@ -53,9 +53,110 @@ fn test_replace_variables_with_array_commands() {
     ];
     let script = Value::Array(commands.into_iter().map(Value::String).collect());
     let args = vec![];
-    
+
     let result = replace_variables(&script, &args).unwrap();
     let array = result.as_array().unwrap();
     assert_eq!(array[0].as_str().unwrap(), "echo hello");
     assert_eq!(array[1].as_str().unwrap(), "echo world");
-} 
+}
+
+// --- split_command_and_args edge cases ---
+
+#[test]
+fn split_empty_args() {
+    let (command, var_args) = split_command_and_args(&[]);
+    assert_eq!(command, "");
+    assert!(var_args.is_empty());
+}
+
+#[test]
+fn split_multiword_command_name() {
+    // "deploy production" is a single command name with two words.
+    let args = vec!["deploy".to_string(), "production".to_string()];
+    let (command, var_args) = split_command_and_args(&args);
+    assert_eq!(command, "deploy production");
+    assert!(var_args.is_empty());
+}
+
+#[test]
+fn split_multiword_command_with_flags() {
+    let args = vec![
+        "deploy".to_string(),
+        "production".to_string(),
+        "--env=prod".to_string(),
+    ];
+    let (command, var_args) = split_command_and_args(&args);
+    assert_eq!(command, "deploy production");
+    assert_eq!(var_args, vec!["--env=prod"]);
+}
+
+#[test]
+fn split_flags_only() {
+    let args = vec!["--only=flags".to_string()];
+    let (command, var_args) = split_command_and_args(&args);
+    assert_eq!(command, "");
+    assert_eq!(var_args, vec!["--only=flags"]);
+}
+
+#[test]
+fn split_positional_after_first_flag_stays_with_args() {
+    // Once a flag appears, everything after it is treated as an argument,
+    // even bare words — they must not rejoin the command name.
+    let args = vec![
+        "run".to_string(),
+        "--flag=1".to_string(),
+        "trailing".to_string(),
+    ];
+    let (command, var_args) = split_command_and_args(&args);
+    assert_eq!(command, "run");
+    assert_eq!(var_args, vec!["--flag=1", "trailing"]);
+}
+
+// --- replace_variables error / override cases ---
+
+#[test]
+fn missing_required_variable_errors() {
+    let script = Value::String("echo {{NAME}}".to_string());
+    let err = replace_variables(&script, &[]).unwrap_err();
+    assert!(err.to_string().contains("Missing required variable"), "{err}");
+}
+
+#[test]
+fn missing_enum_variable_errors() {
+    let script = Value::String("deploy {{env=[staging,prod]}}".to_string());
+    let err = replace_variables(&script, &[]).unwrap_err();
+    assert!(err.to_string().contains("Missing required variable"), "{err}");
+}
+
+#[test]
+fn provided_arg_overrides_default() {
+    let script = Value::String("build {{mode=debug}}".to_string());
+    let args = vec!["--mode=release".to_string()];
+    let result = replace_variables(&script, &args).unwrap();
+    assert_eq!(result.as_str().unwrap(), "build release");
+}
+
+#[test]
+fn enum_tolerates_spaces_in_definition() {
+    // Robin's own templates use "{{env=[staging, prod]}}" with a space.
+    let script = Value::String("deploy {{env=[staging, prod]}}".to_string());
+    let args = vec!["--env=prod".to_string()];
+    let result = replace_variables(&script, &args).unwrap();
+    assert_eq!(result.as_str().unwrap(), "deploy prod");
+}
+
+#[test]
+fn repeated_variable_is_replaced_everywhere() {
+    let script = Value::String("{{x}} and {{x}}".to_string());
+    let args = vec!["--x=hi".to_string()];
+    let result = replace_variables(&script, &args).unwrap();
+    assert_eq!(result.as_str().unwrap(), "hi and hi");
+}
+
+#[test]
+fn non_string_script_is_returned_unchanged() {
+    // Numbers/objects aren't templated; they pass through as-is.
+    let script = Value::from(42);
+    let result = replace_variables(&script, &[]).unwrap();
+    assert_eq!(result, Value::from(42));
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,9 @@
+use robin::CONFIG_FILE;
 use std::path::PathBuf;
 use tempfile::TempDir;
-use robin::CONFIG_FILE;
 
 pub async fn setup() -> (TempDir, PathBuf) {
     let temp_dir = tempfile::tempdir().unwrap();
     let config_path = temp_dir.path().join(CONFIG_FILE);
     (temp_dir, config_path)
-} 
+}

--- a/tests/config_load_tests.rs
+++ b/tests/config_load_tests.rs
@@ -58,9 +58,18 @@ fn includes_are_merged_with_base_taking_precedence() {
 
     let config = RobinConfig::load(&base).unwrap();
 
-    assert_eq!(config.scripts.get("shared").unwrap().as_str().unwrap(), "base wins");
-    assert_eq!(config.scripts.get("only_base").unwrap().as_str().unwrap(), "b");
-    assert_eq!(config.scripts.get("only_child").unwrap().as_str().unwrap(), "c");
+    assert_eq!(
+        config.scripts.get("shared").unwrap().as_str().unwrap(),
+        "base wins"
+    );
+    assert_eq!(
+        config.scripts.get("only_base").unwrap().as_str().unwrap(),
+        "b"
+    );
+    assert_eq!(
+        config.scripts.get("only_child").unwrap().as_str().unwrap(),
+        "c"
+    );
     assert_eq!(config.scripts.len(), 3);
 }
 

--- a/tests/config_load_tests.rs
+++ b/tests/config_load_tests.rs
@@ -1,0 +1,108 @@
+use robin::config::RobinConfig;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn load_missing_file_gives_helpful_error() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(".robin.json");
+
+    let err = RobinConfig::load(&path).unwrap_err();
+    assert!(
+        err.to_string().contains("No .robin.json found"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn load_malformed_json_gives_helpful_error() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(".robin.json");
+    fs::write(&path, "{ this is not valid json ").unwrap();
+
+    let err = RobinConfig::load(&path).unwrap_err();
+    assert!(
+        err.to_string().contains("malformed JSON"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn load_defaults_include_to_empty() {
+    // `include` is optional; a config without it must still load.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(".robin.json");
+    fs::write(&path, r#"{"scripts":{"build":"cargo build"}}"#).unwrap();
+
+    let config = RobinConfig::load(&path).unwrap();
+    assert!(config.include.is_empty());
+    assert_eq!(config.scripts.len(), 1);
+}
+
+#[test]
+fn includes_are_merged_with_base_taking_precedence() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".robin.json");
+    let child = dir.path().join("child.json");
+
+    fs::write(
+        &base,
+        r#"{"include":["child.json"],"scripts":{"shared":"base wins","only_base":"b"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        &child,
+        r#"{"scripts":{"shared":"child loses","only_child":"c"}}"#,
+    )
+    .unwrap();
+
+    let config = RobinConfig::load(&base).unwrap();
+
+    assert_eq!(config.scripts.get("shared").unwrap().as_str().unwrap(), "base wins");
+    assert_eq!(config.scripts.get("only_base").unwrap().as_str().unwrap(), "b");
+    assert_eq!(config.scripts.get("only_child").unwrap().as_str().unwrap(), "c");
+    assert_eq!(config.scripts.len(), 3);
+}
+
+#[test]
+fn includes_resolve_relative_to_config_dir() {
+    // The included path is resolved against the parent of the config file,
+    // not the process's current directory.
+    let dir = tempdir().unwrap();
+    let sub = dir.path().join("sub");
+    fs::create_dir(&sub).unwrap();
+
+    let base = sub.join(".robin.json");
+    fs::write(&base, r#"{"include":["extra.json"],"scripts":{"a":"1"}}"#).unwrap();
+    fs::write(sub.join("extra.json"), r#"{"scripts":{"b":"2"}}"#).unwrap();
+
+    let config = RobinConfig::load(&base).unwrap();
+    assert!(config.scripts.contains_key("a"));
+    assert!(config.scripts.contains_key("b"));
+}
+
+#[test]
+fn missing_include_reports_which_file_failed() {
+    let dir = tempdir().unwrap();
+    let base = dir.path().join(".robin.json");
+    fs::write(&base, r#"{"include":["does_not_exist.json"],"scripts":{}}"#).unwrap();
+
+    let err = RobinConfig::load(&base).unwrap_err();
+    assert!(
+        err.to_string().contains("does_not_exist.json"),
+        "error should name the missing include: {err}"
+    );
+}
+
+#[test]
+fn save_then_load_roundtrips() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(".robin.json");
+
+    let config = RobinConfig::create_template();
+    config.save(&path).unwrap();
+    assert!(path.exists());
+
+    let loaded = RobinConfig::load(&path).unwrap();
+    assert_eq!(loaded.scripts.len(), config.scripts.len());
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -7,11 +7,11 @@ use robin::fetch_template;
 #[tokio::test]
 async fn test_init_without_template() {
     let (_temp_dir, config_path) = common::setup().await;
-    
+
     // Test init without template
     let config = RobinConfig::create_template();
     config.save(&config_path).unwrap();
-    
+
     assert!(config_path.exists());
     let loaded_config = RobinConfig::load(&config_path).unwrap();
     assert_eq!(loaded_config.scripts.len(), config.scripts.len());
@@ -20,10 +20,10 @@ async fn test_init_without_template() {
 #[tokio::test]
 async fn test_init_with_template() {
     let (_temp_dir, config_path) = common::setup().await;
-    
+
     let config = fetch_template("node").await.unwrap();
     config.save(&config_path).unwrap();
-    
+
     assert!(config_path.exists());
     let loaded_config = RobinConfig::load(&config_path).unwrap();
     assert!(loaded_config.scripts.contains_key("start"));
@@ -33,18 +33,23 @@ async fn test_init_with_template() {
 async fn test_add_command() {
     let (_temp_dir, config_path) = common::setup().await;
     let mut config = RobinConfig::create_template();
-    
+
     let script_name = "test";
     let script_content = "echo 'test'";
     config.scripts.insert(
         script_name.to_string(),
-        serde_json::Value::String(script_content.to_string())
+        serde_json::Value::String(script_content.to_string()),
     );
     config.save(&config_path).unwrap();
-    
+
     let loaded_config = RobinConfig::load(&config_path).unwrap();
     assert_eq!(
-        loaded_config.scripts.get(script_name).unwrap().as_str().unwrap(),
+        loaded_config
+            .scripts
+            .get(script_name)
+            .unwrap()
+            .as_str()
+            .unwrap(),
         script_content
     );
-} 
+}

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -8,7 +8,10 @@ fn config_with(scripts: &[(&str, Value)]) -> RobinConfig {
     for (name, script) in scripts {
         map.insert((*name).to_string(), script.clone());
     }
-    RobinConfig { include: vec![], scripts: map }
+    RobinConfig {
+        include: vec![],
+        scripts: map,
+    }
 }
 
 #[test]
@@ -31,7 +34,10 @@ fn check_environment_probes_detected_tools() {
     let config = config_with(&[("status", json!("git status"))]);
     let (_passed, found, missing, _duration) = check_environment(&config).unwrap();
 
-    assert!(found + missing >= 1, "git should trigger at least one check");
+    assert!(
+        found + missing >= 1,
+        "git should trigger at least one check"
+    );
 }
 
 #[test]

--- a/tests/doctor_tests.rs
+++ b/tests/doctor_tests.rs
@@ -1,24 +1,46 @@
-mod common;
-
+use robin::config::RobinConfig;
 use robin::tools::{check_environment, update_tools};
+use serde_json::{Value, json};
+use std::collections::HashMap;
 
-#[test]
-fn test_doctor_command() {
-    let result = check_environment();
-    assert!(result.is_ok());
-    
-    let (success, found, missing, duration) = result.unwrap();
-    assert!(duration.as_secs_f32() >= 0.0);
-    assert!(found + missing > 0);
+fn config_with(scripts: &[(&str, Value)]) -> RobinConfig {
+    let mut map = HashMap::new();
+    for (name, script) in scripts {
+        map.insert((*name).to_string(), script.clone());
+    }
+    RobinConfig { include: vec![], scripts: map }
 }
 
 #[test]
-fn test_doctor_update() {
-    let result = update_tools();
-    assert!(result.is_ok());
-    
-    let (success, updated_tools) = result.unwrap();
-    if success {
-        assert!(!updated_tools.is_empty(), "Should have updated at least one tool");
-    }
-} 
+fn check_environment_reports_nothing_for_toolless_config() {
+    // A config that references no known tool must short-circuit to an
+    // all-clear with zero checks — no shelling out, fully hermetic.
+    let config = config_with(&[("hello", json!("echo hello world"))]);
+    let (passed, found, missing, duration) = check_environment(&config).unwrap();
+
+    assert!(passed);
+    assert_eq!(found, 0);
+    assert_eq!(missing, 0);
+    assert!(duration.as_secs_f32() >= 0.0);
+}
+
+#[test]
+fn check_environment_probes_detected_tools() {
+    // git is detected and probed (read-only `git --version` / `git config`).
+    // Whether or not git is installed, at least one check must be recorded.
+    let config = config_with(&[("status", json!("git status"))]);
+    let (_passed, found, missing, _duration) = check_environment(&config).unwrap();
+
+    assert!(found + missing >= 1, "git should trigger at least one check");
+}
+
+#[test]
+fn update_tools_is_a_noop_without_updatable_tools() {
+    // echo and git are not in the updatable set, so this must NOT execute any
+    // real update command (no rustup/npm/gem/flutter/pod side effects).
+    let config = config_with(&[("hello", json!("echo hi")), ("status", json!("git status"))]);
+    let (success, updated) = update_tools(&config).unwrap();
+
+    assert!(success);
+    assert!(updated.is_empty(), "no updatable tools => nothing updated");
+}

--- a/tests/script_tests.rs
+++ b/tests/script_tests.rs
@@ -46,4 +46,30 @@ async fn test_run_script_with_error() {
     let script = Value::String("nonexistent_command".to_string());
     let result = run_script(&script, false);
     assert!(result.is_err());
+}
+
+#[test]
+fn run_script_array_stops_on_first_failure() {
+    // The failing command is in the middle; the sequence must error out.
+    let scripts = Value::Array(vec![
+        Value::String("echo first".to_string()),
+        Value::String("false".to_string()),
+        Value::String("echo should-not-matter".to_string()),
+    ]);
+    let result = run_script(&scripts, false);
+    assert!(result.is_err());
+}
+
+#[test]
+fn run_script_rejects_invalid_script_type() {
+    let script = Value::from(42);
+    let err = run_script(&script, false).unwrap_err();
+    assert!(err.to_string().contains("Invalid script type"), "{err}");
+}
+
+#[test]
+fn list_commands_errors_without_config() {
+    use std::path::Path;
+    let result = list_commands(Path::new("/definitely/not/here/.robin.json"));
+    assert!(result.is_err());
 } 

--- a/tests/script_tests.rs
+++ b/tests/script_tests.rs
@@ -1,25 +1,25 @@
 mod common;
 
-use robin::scripts::{run_script, list_commands};
 use robin::config::RobinConfig;
+use robin::scripts::{list_commands, run_script};
 use serde_json::Value;
 
 #[tokio::test]
 async fn test_list_commands() {
     let (_temp_dir, config_path) = common::setup().await;
     let mut config = RobinConfig::create_template();
-    
+
     config.scripts.insert(
         "test1".to_string(),
-        Value::String("echo 'test1'".to_string())
+        Value::String("echo 'test1'".to_string()),
     );
     config.scripts.insert(
         "test2".to_string(),
-        Value::String("echo 'test2'".to_string())
+        Value::String("echo 'test2'".to_string()),
     );
-    
+
     config.save(&config_path).unwrap();
-    
+
     let result = list_commands(&config_path);
     assert!(result.is_ok());
 }
@@ -35,7 +35,7 @@ async fn test_run_script() {
 async fn test_run_multiple_scripts() {
     let scripts = Value::Array(vec![
         Value::String("echo 'test1'".to_string()),
-        Value::String("echo 'test2'".to_string())
+        Value::String("echo 'test2'".to_string()),
     ]);
     let result = run_script(&scripts, false);
     assert!(result.is_ok());
@@ -72,4 +72,4 @@ fn list_commands_errors_without_config() {
     use std::path::Path;
     let result = list_commands(Path::new("/definitely/not/here/.robin.json"));
     assert!(result.is_err());
-} 
+}


### PR DESCRIPTION
This PR modernizes the project and substantially raises confidence in it. Work is split into focused commits.

## Dependencies & toolchain
- Bump every outdated dependency (majors: `colored` 2→3, `dialoguer` 0.11→0.12, `inquire` 0.6→0.9, `reqwest` 0.11→0.13; plus minors) and refresh `Cargo.lock`.
- Remove three unused crates: `dirs`, `thiserror`, `fuzzy-matcher` (`dirs` is re-added later for the update-check cache).
- Move to **Rust edition 2024** (`rust-version = "1.85"`).

## Build & release tooling
- Add a `Makefile` inspired by the standard Rust CLI template: `make test` (nextest + doctests), `make release`, plus build/install/check/fmt/lint/run.
- Wire `cargo-release` via `release.toml` + `scripts/prepare_release.py` to auto-generate Keep-a-Changelog notes; seed `CHANGELOG.md`.

## Correctness fix (found via new tests)
- **Tool detection false positive:** `cargo build` was detected as needing the Go toolchain because a plain substring check matched `"go "` inside `"car`**`go`**`"`. Detection now only matches at a command boundary (start of string or after whitespace / a shell separator).

## Test coverage: 11 → 48 tests
- Made `check_environment`/`update_tools` take a `&RobinConfig` instead of loading `.robin.json` from the cwd. This **removed a dangerous test that ran a live `rustup update` on every `cargo test`** and makes detection logic testable hermetically. Whole suite now runs in ~0.2s (was 10s+).
- Added tests for: config include-merging (precedence, relative resolution, missing-include errors), load errors, multi-word command parsing, `replace_variables` error/override paths, `run_script` stop-on-failure/invalid-type, tool detection (incl. cargo/go regression), and version comparison.

## Update notifications
- After a command runs, robin checks crates.io and prints a short notice if a newer version exists.
- Throttled to **at most once per day** (cached under the OS cache dir), runs after the command, 2s timeout, swallows all errors, opt-out via `ROBIN_NO_UPDATE_CHECK`.

## Housekeeping
- `cargo fmt` across the crate so `make lint` passes; cleared all clippy warnings (`-D warnings` clean).
- Fixed CI to trigger on `main` (the default branch) instead of `master`, so the workflow actually runs.

## Verification
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` are all clean.
- `make test`: 48 passed (46 unit/integration + doctests), 0 failed.