### PR TITLE
feat: support Docker-style ${VAR:-default} environment defaults

### DIFF
--- a/.base_robin.json
+++ b/.base_robin.json
@@ -19,6 +19,7 @@
     "test": "cargo test",
     "fmt": "cargo fmt --all -- --check",
     "build:mode": "cargo build --{{mode=[debug, release]}}",
-    "test:type": "cargo test --{{type=[lib, doc, all]}}"
+    "test:type": "cargo test --{{type=[lib, doc, all]}}",
+    "serve": "echo starting on port ${PORT:-8080}"
   }
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - Template initialization for different project types
 - Variable substitution with default values
 - Enum validation for variables
+- Environment variable substitution with defaults (`${VAR:-default}`)
 
 ## Installation
 
@@ -311,6 +312,34 @@ Variables work in both single commands and command sequences:
     }
 }
 ```
+
+### Environment Variables with Defaults
+In addition to the `{{...}}` syntax (which reads from `--variable=` arguments), you can
+read values from the **environment** using Docker Compose-style `${VAR:-default}` syntax:
+
+```json
+{
+    "scripts": {
+        "serve": "echo \"starting on port ${PORT:-8080}\"",
+        "deploy": "kubectl apply -n ${NAMESPACE:-default} -f deploy.yaml"
+    }
+}
+```
+
+```bash
+robin serve              # PORT unset -> "starting on port 8080"
+PORT=9000 robin serve    # PORT set   -> "starting on port 9000"
+```
+
+Two forms are supported (defaults only):
+
+| Syntax | Behavior |
+|--------|----------|
+| `${VAR:-default}` | Use `$VAR` if it is set **and non-empty**, otherwise `default`. |
+| `${VAR-default}`  | Use `$VAR` if it is **set** (even if empty), otherwise `default`. |
+
+A bare `${VAR}` (with no default) is left untouched and expanded by the shell at run
+time, exactly as before.
 
 ## Development Environment
 

--- a/src/utils/command_utils.rs
+++ b/src/utils/command_utils.rs
@@ -47,11 +47,46 @@ pub fn replace_variables(script: &serde_json::Value, args: &[String]) -> Result<
     }
 }
 
-fn replace_variables_in_string(script: &str, args: &[String]) -> Result<String> {
-    let var_regex = Regex::new(r"\{\{(\w+)(?:=([^}]+|\[[^\]]+\]))?\}\}").unwrap();
+/// Replaces Docker Compose-style environment-variable defaults.
+///
+/// Supports two forms (defaults only):
+///   - `${VAR:-default}` -> use `$VAR` if set and non-empty, otherwise `default`.
+///   - `${VAR-default}`  -> use `$VAR` if set (even if empty), otherwise `default`.
+///
+/// Bare `${VAR}` (no operator) is intentionally left untouched so it is still
+/// expanded by the shell at run time.
+fn replace_env_variables_in_string(script: &str) -> String {
+    let env_regex = Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-)([^}]*)\}").unwrap();
     let mut result = script.to_string();
 
-    for capture in var_regex.captures_iter(script) {
+    for capture in env_regex.captures_iter(script) {
+        let full_match = &capture[0];
+        let var_name = &capture[1];
+        let operator = &capture[2];
+        let default = &capture[3];
+
+        let env_value = std::env::var(var_name).ok();
+        let value = match operator {
+            ":-" => match env_value {
+                Some(v) if !v.is_empty() => v,
+                _ => default.to_string(),
+            },
+            // "-": use the env value whenever the variable is set, even if empty.
+            _ => env_value.unwrap_or_else(|| default.to_string()),
+        };
+
+        result = result.replace(full_match, &value);
+    }
+
+    result
+}
+
+fn replace_variables_in_string(script: &str, args: &[String]) -> Result<String> {
+    let script = replace_env_variables_in_string(script);
+    let var_regex = Regex::new(r"\{\{(\w+)(?:=([^}]+|\[[^\]]+\]))?\}\}").unwrap();
+    let mut result = script.clone();
+
+    for capture in var_regex.captures_iter(&script) {
         let full_match = &capture[0];
         let var_name = &capture[1];
         let default_or_enum = capture.get(2).map(|m| m.as_str()).unwrap_or("");

--- a/tests/command_tests.rs
+++ b/tests/command_tests.rs
@@ -167,3 +167,99 @@ fn non_string_script_is_returned_unchanged() {
     let result = replace_variables(&script, &[]).unwrap();
     assert_eq!(result, Value::from(42));
 }
+
+// --- Docker Compose-style ${VAR:-default} environment substitution ---
+//
+// Each test uses a unique env-var name so it can't interfere with other tests
+// running in parallel. Helpers wrap the unsafe env mutations (Rust 2024).
+
+fn set_env(key: &str, value: &str) {
+    unsafe { std::env::set_var(key, value) };
+}
+
+fn unset_env(key: &str) {
+    unsafe { std::env::remove_var(key) };
+}
+
+#[test]
+fn env_default_used_when_var_unset() {
+    let key = "ROBIN_TEST_UNSET_PORT";
+    unset_env(key);
+    let script = Value::String(format!("serve on ${{{key}:-8080}}"));
+    let result = replace_variables(&script, &[]).unwrap();
+    assert_eq!(result.as_str().unwrap(), "serve on 8080");
+}
+
+#[test]
+fn env_value_used_when_var_set() {
+    let key = "ROBIN_TEST_SET_PORT";
+    set_env(key, "9000");
+    let script = Value::String(format!("serve on ${{{key}:-8080}}"));
+    let result = replace_variables(&script, &[]).unwrap();
+    assert_eq!(result.as_str().unwrap(), "serve on 9000");
+    unset_env(key);
+}
+
+#[test]
+fn colon_dash_treats_empty_as_unset() {
+    // `${VAR:-default}` falls back to the default when the var is set but empty.
+    let key = "ROBIN_TEST_EMPTY_COLON";
+    set_env(key, "");
+    let script = Value::String(format!("x=${{{key}:-fallback}}"));
+    let result = replace_variables(&script, &[]).unwrap();
+    assert_eq!(result.as_str().unwrap(), "x=fallback");
+    unset_env(key);
+}
+
+#[test]
+fn dash_keeps_empty_value() {
+    // `${VAR-default}` (no colon) uses the empty value because the var IS set.
+    let key = "ROBIN_TEST_EMPTY_DASH";
+    set_env(key, "");
+    let script = Value::String(format!("x=[${{{key}-fallback}}]"));
+    let result = replace_variables(&script, &[]).unwrap();
+    assert_eq!(result.as_str().unwrap(), "x=[]");
+    unset_env(key);
+}
+
+#[test]
+fn dash_uses_default_when_unset() {
+    let key = "ROBIN_TEST_DASH_UNSET";
+    unset_env(key);
+    let script = Value::String(format!("x=${{{key}-fallback}}"));
+    let result = replace_variables(&script, &[]).unwrap();
+    assert_eq!(result.as_str().unwrap(), "x=fallback");
+}
+
+#[test]
+fn env_and_arg_syntaxes_coexist() {
+    let key = "ROBIN_TEST_COEXIST";
+    unset_env(key);
+    let script = Value::String(format!("deploy {{{{target}}}} to ${{{key}:-staging}}"));
+    let args = vec!["--target=api".to_string()];
+    let result = replace_variables(&script, &args).unwrap();
+    assert_eq!(result.as_str().unwrap(), "deploy api to staging");
+}
+
+#[test]
+fn env_default_applied_across_array_commands() {
+    let key = "ROBIN_TEST_ARRAY";
+    unset_env(key);
+    let commands = vec![
+        format!("echo ${{{key}:-one}}"),
+        format!("echo ${{{key}:-two}}"),
+    ];
+    let script = Value::Array(commands.into_iter().map(Value::String).collect());
+    let result = replace_variables(&script, &[]).unwrap();
+    let array = result.as_array().unwrap();
+    assert_eq!(array[0].as_str().unwrap(), "echo one");
+    assert_eq!(array[1].as_str().unwrap(), "echo two");
+}
+
+#[test]
+fn bare_env_var_is_left_for_the_shell() {
+    // No default operator -> robin must not touch it; the shell expands it later.
+    let script = Value::String("echo ${HOME}".to_string());
+    let result = replace_variables(&script, &[]).unwrap();
+    assert_eq!(result.as_str().unwrap(), "echo ${HOME}");
+}


### PR DESCRIPTION
## Summary

Adds Docker Compose-style environment-variable substitution with defaults to `.robin.json` script commands, complementing the existing `{{var}}` CLI-arg system (which reads from `--var=value`). Until now there was no way to source a value from the environment or give it a fallback.

Two forms are supported (defaults only):

| Syntax | Behavior |
|--------|----------|
| `${VAR:-default}` | Use `$VAR` if set **and non-empty**, otherwise `default`. |
| `${VAR-default}`  | Use `$VAR` if **set** (even if empty), otherwise `default`. |

A bare `${VAR}` (no operator) is intentionally left untouched and expanded by the shell at run time — so existing scripts are unaffected.

```json
{ "scripts": { "serve": "echo starting on port ${PORT:-8080}" } }
```
```bash
robin serve            # -> starting on port 8080
PORT=9000 robin serve  # -> starting on port 9000
```

## Changes

- `src/utils/command_utils.rs`: new `replace_env_variables_in_string` pass, run before the existing `{{...}}` substitution.
- `tests/command_tests.rs`: 8 new cases (unset→default, set→value, `:-` vs `-` empty handling, coexistence with `{{arg}}`, arrays, bare-`${VAR}` passthrough).
- `README.md`: documents the new syntax; `.base_robin.json`: illustrative `serve` example.

## Verification

- `cargo test` — all suites green (24 command tests incl. new env-var cases)
- `cargo clippy --all-targets` — clean
- Manual end-to-end confirmed for set/unset `PORT`