### PR TITLE
Add robin --make to run Makefile targets as tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ That's it. Read on for templates, variables, sequences, and more.
 - Environment variable substitution with defaults (`${VAR:-default}`)
 - Automatic `.env` file loading
 - Optional per-task descriptions (shown in `--list` and interactive mode)
+- Read Makefile targets with `--make` (list, interactive picker, and run via `make`)
 - Reference other tasks from a sequence with `@task`
 - Optional desktop notification on completion with `--notify`
 
@@ -109,12 +110,14 @@ If a `.robin.json` file already exists, you'll be prompted to confirm before ove
 
 ```bash
 robin --list
+robin --make --list   # list Makefile targets instead of .robin.json tasks
 ```
 
 ### Interactive mode
 
 ```bash
 robin --interactive  # or -i
+robin --make         # pick a Makefile target interactively
 ```
 
 ### Add a new command

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,8 +12,11 @@ description: Use when a project contains a .robin.json (or .base_robin.json / .a
 | Goal | Command |
 |------|---------|
 | List every task (with descriptions) | `robin --list` (`-l`) |
+| List Makefile targets | `robin --make --list` |
 | Pick a task interactively (fuzzy) | `robin --interactive` (`-i`) |
+| Pick a Makefile target interactively | `robin --make` or `robin --make -i` |
 | Run a task | `robin <task>` |
+| Run a Makefile target | `robin --make <target>` |
 | Run with variables | `robin deploy --env=staging --platform=ios` |
 | Preview without executing | `robin <task> --dry-run` |
 | Run in another directory | `robin <task> --cwd ./path` |
@@ -23,7 +26,20 @@ description: Use when a project contains a .robin.json (or .base_robin.json / .a
 | Add `desc` scaffolding to every task | `robin migrate` |
 | Check the dev environment | `robin doctor` · `robin doctor-update` |
 
-Robin searches the current directory and walks **up** to find `.robin.json`, so tasks run from anywhere inside the project. `--dry-run`, `--cwd`, and `--notify` work before or after the task name.
+Robin searches the current directory and walks **up** to find `.robin.json`, so tasks run from anywhere inside the project. `--dry-run`, `--cwd`, `--notify`, and `--make` work before or after the task name.
+
+## Makefile mode (`--make`)
+
+When a project has a `Makefile` (or `makefile` / `GNUmakefile`) but no `.robin.json` — or you simply prefer Make targets — use `--make` to treat Makefile targets as robin tasks:
+
+```bash
+robin --make --list          # list targets with recipe previews / comments
+robin --make                 # interactive picker over Makefile targets
+robin --make build           # run `make -C <makefile-dir> build`
+robin build --make           # same; robin flags also work after the target name
+```
+
+Robin walks up from the current directory to find the Makefile, mirroring `.robin.json` discovery. Each target runs via `make` so dependencies, variables, and `.PHONY` rules behave normally. Comments on the line above a target become the task description in `--list` and the interactive picker.
 
 ## Config format (`.robin.json`)
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -25,6 +25,10 @@ pub struct Cli {
     /// Run the task's commands in this directory instead of the current one
     #[arg(long, value_name = "DIR")]
     pub cwd: Option<std::path::PathBuf>,
+
+    /// Read tasks from a Makefile in this directory (or an ancestor)
+    #[arg(long)]
+    pub make: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,5 @@
 mod robin_config;
 
 pub use robin_config::{
-    RobinConfig, SCHEMA_URL, find_config_from, find_config_path, script_command,
-    script_description,
+    RobinConfig, SCHEMA_URL, find_config_from, find_config_path, script_command, script_description,
 };

--- a/src/config/robin_config.rs
+++ b/src/config/robin_config.rs
@@ -10,8 +10,7 @@ use crate::CONFIG_FILE;
 /// Canonical location of the published JSON Schema for `.robin.json`. Generated
 /// configs point their `$schema` here so editors can offer autocomplete and
 /// validation.
-pub const SCHEMA_URL: &str =
-    "https://raw.githubusercontent.com/cesarferreira/robin/refs/heads/main/schema/robin.schema.json";
+pub const SCHEMA_URL: &str = "https://raw.githubusercontent.com/cesarferreira/robin/refs/heads/main/schema/robin.schema.json";
 
 /// Walks up from `start` (inclusive) looking for the first directory that
 /// contains a `.robin.json`. Returns the path to that config, or `None` when no
@@ -198,10 +197,7 @@ impl RobinConfig {
         Self {
             // Ensure the migrated file points at the schema for editor tooling,
             // keeping any pointer the user already set.
-            schema: self
-                .schema
-                .clone()
-                .or_else(|| Some(SCHEMA_URL.to_string())),
+            schema: self.schema.clone().or_else(|| Some(SCHEMA_URL.to_string())),
             include: self.include.clone(),
             scripts,
         }
@@ -215,7 +211,10 @@ mod tests {
 
     #[test]
     fn script_command_reads_bare_string_and_array() {
-        assert_eq!(script_command(&json!("cargo build")), Some(&json!("cargo build")));
+        assert_eq!(
+            script_command(&json!("cargo build")),
+            Some(&json!("cargo build"))
+        );
         let arr = json!(["a", "b"]);
         assert_eq!(script_command(&arr), Some(&arr));
     }
@@ -295,10 +294,7 @@ mod tests {
         let mut scripts = HashMap::new();
         scripts.insert("s".to_string(), json!("cargo build"));
         scripts.insert("a".to_string(), json!(["x", "y"]));
-        scripts.insert(
-            "o".to_string(),
-            json!({ "cmd": "already", "desc": "kept" }),
-        );
+        scripts.insert("o".to_string(), json!({ "cmd": "already", "desc": "kept" }));
         let config = RobinConfig {
             schema: None,
             include: vec!["base.json".to_string()],
@@ -307,9 +303,18 @@ mod tests {
 
         let migrated = config.migrated();
 
-        assert_eq!(migrated.scripts["s"], json!({ "cmd": "cargo build", "desc": "" }));
-        assert_eq!(migrated.scripts["a"], json!({ "cmd": ["x", "y"], "desc": "" }));
-        assert_eq!(migrated.scripts["o"], json!({ "cmd": "already", "desc": "kept" }));
+        assert_eq!(
+            migrated.scripts["s"],
+            json!({ "cmd": "cargo build", "desc": "" })
+        );
+        assert_eq!(
+            migrated.scripts["a"],
+            json!({ "cmd": ["x", "y"], "desc": "" })
+        );
+        assert_eq!(
+            migrated.scripts["o"],
+            json!({ "cmd": "already", "desc": "kept" })
+        );
         // `include` is preserved untouched.
         assert_eq!(migrated.include, vec!["base.json".to_string()]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ const GITHUB_TEMPLATE_BASE: &str =
 
 pub mod cli;
 pub mod config;
+pub mod makefile;
 pub mod scripts;
 pub mod tools;
 pub mod utils;
@@ -12,9 +13,10 @@ pub use cli::{Cli, Commands};
 pub use config::{
     RobinConfig, find_config_from, find_config_path, script_command, script_description,
 };
+pub use makefile::{find_makefile_from, find_makefile_path, load_makefile_scripts, parse_makefile};
 pub use scripts::{
-    command_lines, interactive_mode, list_commands, resolve_task_command, run_script,
-    run_script_in,
+    command_lines, interactive_mode, interactive_scripts, list_commands, list_scripts,
+    resolve_task_command, run_script, run_script_in,
 };
 pub use tools::{check_environment, update_tools};
 pub use utils::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use std::path::PathBuf;
 
 use robin::{
     CONFIG_FILE, Cli, Commands, RobinConfig, check_environment, check_for_update, command_lines,
-    find_config_path, interactive_mode, list_commands, load_env_file, replace_variables,
-    resolve_task_command, run_script_in, script_command, send_notification, split_command_and_args,
-    update_tools,
+    find_config_path, find_makefile_path, interactive_mode, interactive_scripts, list_commands,
+    list_scripts, load_env_file, load_makefile_scripts, replace_variables, resolve_task_command,
+    run_script_in, script_command, send_notification, split_command_and_args, update_tools,
 };
 
 const GITHUB_TEMPLATE_BASE: &str =
@@ -50,6 +50,7 @@ async fn dispatch(cli: &Cli) -> Result<()> {
     // current directory; `init` always targets the current directory so it never
     // overwrites a parent project's config.
     let config_path = find_config_path();
+    let makefile_path = find_makefile_path();
 
     match &cli.command {
         Some(Commands::Init { template }) => {
@@ -116,7 +117,13 @@ async fn dispatch(cli: &Cli) -> Result<()> {
 
             config.rename_script(from, to)?;
             config.save(&config_path)?;
-            println!("{} {} {} {}", "Renamed command:".green(), from, "→".dimmed(), to);
+            println!(
+                "{} {} {} {}",
+                "Renamed command:".green(),
+                from,
+                "→".dimmed(),
+                to
+            );
         }
 
         Some(Commands::Migrate) => {
@@ -169,12 +176,17 @@ async fn dispatch(cli: &Cli) -> Result<()> {
         }
 
         Some(Commands::Run(args)) => {
-            let config = RobinConfig::load(&config_path)
-                .with_context(|| "No .robin.json found. Run 'robin init' first")?;
-
-            // Load a `.env` sitting next to the config so tasks and variable
-            // substitution can use it.
-            load_env_file(&config_path);
+            let make_mode = cli.make || args.iter().any(|a| a == "--make");
+            let scripts = if make_mode {
+                load_makefile_scripts(&makefile_path)?
+            } else {
+                let config = RobinConfig::load(&config_path)
+                    .with_context(|| "No .robin.json found. Run 'robin init' first")?;
+                // Load a `.env` sitting next to the config so tasks and variable
+                // substitution can use it.
+                load_env_file(&config_path);
+                config.scripts
+            };
 
             let (script_name, var_args) = split_command_and_args(args);
 
@@ -189,14 +201,16 @@ async fn dispatch(cli: &Cli) -> Result<()> {
                 .or_else(|| cli.cwd.clone());
             let var_args: Vec<String> = var_args
                 .into_iter()
-                .filter(|a| a != "--dry-run" && a != "--notify" && !a.starts_with("--cwd="))
+                .filter(|a| {
+                    a != "--dry-run" && a != "--notify" && a != "--make" && !a.starts_with("--cwd=")
+                })
                 .collect();
 
-            if let Some(entry) = config.scripts.get(&script_name) {
+            if let Some(entry) = scripts.get(&script_name) {
                 let script = script_command(entry).ok_or_else(|| {
                     anyhow!("Command '{}' has an invalid script definition", script_name)
                 })?;
-                let resolved = resolve_task_command(script, &config.scripts)?;
+                let resolved = resolve_task_command(script, &scripts)?;
                 let script_with_vars = replace_variables(&resolved, &var_args)?;
 
                 if dry_run {
@@ -220,7 +234,14 @@ async fn dispatch(cli: &Cli) -> Result<()> {
         }
 
         None => {
-            if cli.list {
+            if cli.make {
+                let scripts = load_makefile_scripts(&makefile_path)?;
+                if cli.list {
+                    list_scripts(&scripts)?;
+                } else {
+                    interactive_scripts(&scripts)?;
+                }
+            } else if cli.list {
                 list_commands(&config_path)?;
             } else {
                 load_env_file(&config_path);

--- a/src/makefile/mod.rs
+++ b/src/makefile/mod.rs
@@ -1,0 +1,257 @@
+use anyhow::{Context, Result, anyhow};
+use regex::Regex;
+use serde_json::{Value, json};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MAKEFILE_NAMES: &[&str] = &["Makefile", "makefile", "GNUmakefile"];
+
+/// Walks up from `start` (inclusive) looking for a Makefile.
+pub fn find_makefile_from(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(current) = dir {
+        for name in MAKEFILE_NAMES {
+            let candidate = current.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+        dir = current.parent();
+    }
+    None
+}
+
+/// Resolves the Makefile path for read commands: the nearest Makefile found by
+/// walking up from the current directory, falling back to `./Makefile`.
+pub fn find_makefile_path() -> PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    find_makefile_from(&cwd).unwrap_or_else(|| cwd.join("Makefile"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MakefileTarget {
+    name: String,
+    recipe: Vec<String>,
+    description: Option<String>,
+}
+
+/// Parses a Makefile and returns robin-compatible script entries keyed by target
+/// name. Each entry runs the target via `make` so dependencies and variables are
+/// handled correctly.
+pub fn parse_makefile(content: &str, makefile_dir: &Path) -> Result<HashMap<String, Value>> {
+    let targets = parse_targets(content)?;
+    let dir = makefile_dir
+        .canonicalize()
+        .unwrap_or_else(|_| makefile_dir.to_path_buf());
+    let make_cmd = format!("make -C {}", shell_quote(&dir.display().to_string()));
+
+    let mut scripts = HashMap::new();
+    for target in targets {
+        let cmd = format!("{} {}", make_cmd, target.name);
+        let entry = if let Some(desc) = target.description.filter(|s| !s.is_empty()) {
+            json!({ "cmd": cmd, "desc": desc })
+        } else if target.recipe.len() == 1 {
+            json!({ "cmd": cmd, "desc": target.recipe[0] })
+        } else if target.recipe.len() > 1 {
+            json!({ "cmd": cmd, "desc": target.recipe.join(" ; ") })
+        } else {
+            Value::String(cmd)
+        };
+        scripts.insert(target.name, entry);
+    }
+
+    Ok(scripts)
+}
+
+pub fn load_makefile_scripts(path: &Path) -> Result<HashMap<String, Value>> {
+    if !path.exists() {
+        return Err(anyhow!(
+            "No Makefile found. Looked for Makefile, makefile, or GNUmakefile"
+        ));
+    }
+
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read Makefile: {}", path.display()))?;
+
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    parse_makefile(&content, dir)
+}
+
+fn shell_quote(s: &str) -> String {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '-' | '_' | '.'))
+    {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+fn parse_targets(content: &str) -> Result<Vec<MakefileTarget>> {
+    let target_line = Regex::new(
+        r"^([A-Za-z0-9_.][A-Za-z0-9_.$-]*(?:\s+[A-Za-z0-9_.][A-Za-z0-9_.$-]*)*)\s*:([^=].*)?$",
+    )
+    .unwrap();
+
+    let mut phony = HashSet::new();
+    let mut pending_comment: Option<String> = None;
+    let mut targets = Vec::new();
+    let mut i = 0;
+    let lines: Vec<&str> = content.lines().collect();
+
+    while i < lines.len() {
+        let raw = lines[i];
+        let line = raw.trim_end();
+
+        if let Some(rest) = line.strip_prefix(".PHONY:") {
+            for name in rest.split_whitespace() {
+                phony.insert(name.to_string());
+            }
+            pending_comment = None;
+            i += 1;
+            continue;
+        }
+
+        if line.starts_with('#') {
+            pending_comment = Some(line.trim_start_matches('#').trim().to_string());
+            i += 1;
+            continue;
+        }
+
+        if line.is_empty() {
+            i += 1;
+            continue;
+        }
+
+        if let Some(caps) = target_line.captures(line) {
+            let names = caps.get(1).unwrap().as_str();
+            let mut recipe = Vec::new();
+            i += 1;
+
+            while i < lines.len() {
+                let next = lines[i];
+                if next.starts_with('\t') {
+                    let mut cmd = next.trim_start_matches('\t').trim_end().to_string();
+                    while cmd.ends_with('\\') {
+                        cmd.pop();
+                        i += 1;
+                        if i >= lines.len() {
+                            break;
+                        }
+                        cmd.push(' ');
+                        cmd.push_str(lines[i].trim());
+                    }
+                    if !cmd.is_empty() {
+                        recipe.push(cmd);
+                    }
+                    i += 1;
+                    continue;
+                }
+                break;
+            }
+
+            for name in names.split_whitespace() {
+                if should_skip_target(name, &phony) {
+                    continue;
+                }
+                targets.push(MakefileTarget {
+                    name: name.to_string(),
+                    recipe: recipe.clone(),
+                    description: pending_comment.clone(),
+                });
+            }
+            pending_comment = None;
+            continue;
+        }
+
+        pending_comment = None;
+        i += 1;
+    }
+
+    if targets.is_empty() {
+        return Err(anyhow!("No runnable targets found in Makefile"));
+    }
+
+    Ok(targets)
+}
+
+fn should_skip_target(name: &str, phony: &HashSet<String>) -> bool {
+    if name.contains('%') {
+        return true;
+    }
+    name.starts_with('.') && !phony.contains(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_targets_with_comments() {
+        let content = "\
+# Build the project
+build:
+\tcargo build
+
+# Run tests
+test: build
+\tcargo test
+";
+        let scripts = parse_makefile(content, Path::new(".")).unwrap();
+        assert!(scripts.contains_key("build"));
+        assert!(scripts.contains_key("test"));
+        assert_eq!(
+            scripts["build"]["desc"].as_str().unwrap(),
+            "Build the project"
+        );
+        assert!(
+            scripts["build"]["cmd"]
+                .as_str()
+                .unwrap()
+                .ends_with(" build")
+        );
+    }
+
+    #[test]
+    fn parse_phony_and_skip_internal_targets() {
+        let content = "\
+.PHONY: clean
+clean:
+\trm -rf target
+
+.internal:
+\techo hidden
+";
+        let scripts = parse_makefile(content, Path::new(".")).unwrap();
+        assert!(scripts.contains_key("clean"));
+        assert!(!scripts.contains_key(".internal"));
+    }
+
+    #[test]
+    fn parse_multiline_recipe_uses_joined_description() {
+        let content = "\
+demo:
+\techo one
+\techo two
+";
+        let scripts = parse_makefile(content, Path::new(".")).unwrap();
+        assert_eq!(
+            scripts["demo"]["desc"].as_str().unwrap(),
+            "echo one ; echo two"
+        );
+    }
+
+    #[test]
+    fn find_makefile_from_walks_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(dir.path().join("Makefile"), "build:\n\ttrue\n").unwrap();
+
+        assert_eq!(
+            find_makefile_from(&nested),
+            Some(dir.path().join("Makefile"))
+        );
+    }
+}

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -1,6 +1,6 @@
 mod script_runner;
 
 pub use script_runner::{
-    command_lines, interactive_mode, list_commands, resolve_task_command, run_script,
-    run_script_in,
+    command_lines, interactive_mode, interactive_scripts, list_commands, list_scripts,
+    resolve_task_command, run_script, run_script_in,
 };

--- a/src/scripts/script_runner.rs
+++ b/src/scripts/script_runner.rs
@@ -91,7 +91,10 @@ fn resolve_command_str(
                 .get(name)
                 .ok_or_else(|| anyhow!("Referenced task '{}' not found", name))?;
             let referenced = script_command(entry).ok_or_else(|| {
-                anyhow!("Referenced task '{}' has an invalid script definition", name)
+                anyhow!(
+                    "Referenced task '{}' has an invalid script definition",
+                    name
+                )
             })?;
 
             stack.push(name.to_string());
@@ -205,17 +208,19 @@ pub fn run_script_in(script: &serde_json::Value, notify: bool, cwd: Option<&Path
 pub fn list_commands(config_path: &Path) -> Result<()> {
     let config = RobinConfig::load(config_path)
         .with_context(|| "No .robin.json found. Run 'robin init' first")?;
+    list_scripts(&config.scripts)
+}
+
+pub fn list_scripts(scripts: &HashMap<String, Value>) -> Result<()> {
+    if scripts.is_empty() {
+        return Err(anyhow!("No commands available"));
+    }
 
     // Find the longest command name for padding
-    let max_len = config
-        .scripts
-        .keys()
-        .map(|name| name.len())
-        .max()
-        .unwrap_or(0);
+    let max_len = scripts.keys().map(|name| name.len()).max().unwrap_or(0);
 
     // Convert to sorted vec for alphabetical ordering
-    let mut commands: Vec<_> = config.scripts.iter().collect();
+    let mut commands: Vec<_> = scripts.iter().collect();
     commands.sort_by(|a, b| a.0.cmp(b.0));
 
     for (name, script) in commands {
@@ -270,7 +275,11 @@ fn command_choices(scripts: &HashMap<String, Value>) -> Vec<CommandChoice> {
     let mut entries: Vec<(&String, &Value)> = scripts.iter().collect();
     entries.sort_by(|a, b| a.0.cmp(b.0));
 
-    let max_len = entries.iter().map(|(name, _)| name.len()).max().unwrap_or(0);
+    let max_len = entries
+        .iter()
+        .map(|(name, _)| name.len())
+        .max()
+        .unwrap_or(0);
 
     entries
         .into_iter()
@@ -292,13 +301,16 @@ fn command_choices(scripts: &HashMap<String, Value>) -> Vec<CommandChoice> {
 pub fn interactive_mode(config_path: &Path) -> Result<()> {
     let config = RobinConfig::load(config_path)
         .with_context(|| "No .robin.json found. Run 'robin init' first")?;
+    interactive_scripts(&config.scripts)
+}
 
-    if config.scripts.is_empty() {
+pub fn interactive_scripts(scripts: &HashMap<String, Value>) -> Result<()> {
+    if scripts.is_empty() {
         println!("{}", "No commands available".red());
         return Ok(());
     }
 
-    let choices = command_choices(&config.scripts);
+    let choices = command_choices(scripts);
 
     // Fuzzy-match against the plain `search` text (name + description) rather
     // than the colored label inquire would use by default.
@@ -314,9 +326,9 @@ pub fn interactive_mode(config_path: &Path) -> Result<()> {
         .with_scorer(&scorer)
         .prompt()?;
 
-    if let Some(script) = config.scripts.get(&selection.name) {
+    if let Some(script) = scripts.get(&selection.name) {
         if let Some(cmd) = script_command(script) {
-            let resolved = resolve_task_command(cmd, &config.scripts)?;
+            let resolved = resolve_task_command(cmd, scripts)?;
             run_script(&resolved, false)?;
         }
     }
@@ -337,8 +349,14 @@ mod tests {
     #[test]
     fn choices_are_sorted_and_description_column_is_aligned() {
         let mut scripts = HashMap::new();
-        scripts.insert("build".to_string(), json!({ "cmd": "cargo build", "desc": "Compile" }));
-        scripts.insert("deploy".to_string(), json!({ "cmd": "ship", "desc": "Release it" }));
+        scripts.insert(
+            "build".to_string(),
+            json!({ "cmd": "cargo build", "desc": "Compile" }),
+        );
+        scripts.insert(
+            "deploy".to_string(),
+            json!({ "cmd": "ship", "desc": "Release it" }),
+        );
         scripts.insert("clean".to_string(), json!("rm -rf target/"));
 
         let choices = command_choices(&scripts);
@@ -364,7 +382,10 @@ mod tests {
     #[test]
     fn search_text_is_plain_name_plus_description() {
         let mut scripts = HashMap::new();
-        scripts.insert("build".to_string(), json!({ "cmd": "x", "desc": "Compile the app" }));
+        scripts.insert(
+            "build".to_string(),
+            json!({ "cmd": "x", "desc": "Compile the app" }),
+        );
         scripts.insert("clean".to_string(), json!("rm -rf target/"));
 
         let choices = command_choices(&scripts);

--- a/tests/config_load_tests.rs
+++ b/tests/config_load_tests.rs
@@ -148,11 +148,15 @@ fn schema_field_is_preserved_across_load_and_save() {
     .unwrap();
 
     let mut config = RobinConfig::load(&path).unwrap();
-    assert_eq!(config.schema.as_deref(), Some("https://example.com/robin.json"));
+    assert_eq!(
+        config.schema.as_deref(),
+        Some("https://example.com/robin.json")
+    );
 
-    config
-        .scripts
-        .insert("b".to_string(), serde_json::Value::String("echo bye".into()));
+    config.scripts.insert(
+        "b".to_string(),
+        serde_json::Value::String("echo bye".into()),
+    );
     config.save(&path).unwrap();
 
     let reloaded = RobinConfig::load(&path).unwrap();

--- a/tests/makefile_tests.rs
+++ b/tests/makefile_tests.rs
@@ -1,0 +1,27 @@
+use robin::makefile::{load_makefile_scripts, parse_makefile};
+use robin::scripts::list_scripts;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[test]
+fn load_makefile_scripts_reads_targets_from_file() {
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Makefile"),
+        "# Build it\nbuild:\n\tcargo build\n\ntest:\n\tcargo test\n",
+    )
+    .unwrap();
+
+    let scripts = load_makefile_scripts(&dir.path().join("Makefile")).unwrap();
+    assert!(scripts.contains_key("build"));
+    assert!(scripts.contains_key("test"));
+    assert_eq!(scripts["build"]["desc"].as_str().unwrap(), "Build it");
+}
+
+#[test]
+fn list_scripts_prints_makefile_targets() {
+    let content = "build:\n\techo hi\n";
+    let scripts = parse_makefile(content, Path::new(".")).unwrap();
+    let result = list_scripts(&scripts);
+    assert!(result.is_ok());
+}

--- a/tests/script_tests.rs
+++ b/tests/script_tests.rs
@@ -57,7 +57,8 @@ fn resolve_expands_reference_into_referenced_commands() {
         ("build", json!("cargo build")),
         ("deploy", json!(["@build", "scp app server:/srv"])),
     ]);
-    let resolved = resolve_task_command(&json!(["@build", "scp app server:/srv"]), &scripts).unwrap();
+    let resolved =
+        resolve_task_command(&json!(["@build", "scp app server:/srv"]), &scripts).unwrap();
     assert_eq!(resolved, json!(["cargo build", "scp app server:/srv"]));
 }
 


### PR DESCRIPTION
## Summary
- Add a `--make` flag so robin can list, interactively pick, and run targets from a `Makefile`/`makefile`/`GNUmakefile` instead of `.robin.json`.
- Discover the Makefile by walking up from the current directory (mirroring existing `.robin.json` discovery), and run selected targets via `make -C <dir> <target>` so dependencies, variables, and `.PHONY` rules behave normally.
- Parse leading comments above a target as its description, shown in `--list` and the interactive picker; skip pattern rules (`%`) and internal (dot-prefixed, non-.PHONY) targets.
- Refactor script listing/interactive-picker logic (`list_commands`/`interactive_mode`) into config-agnostic helpers (`list_scripts`/`interactive_scripts`) shared by both `.robin.json` and Makefile modes.
- Update README and SKILL.md with `--make` usage.

## Tests
- New `src/makefile/mod.rs` unit tests covering target parsing (comments, `.PHONY`, multiline recipes) and Makefile discovery by walking up directories.
- New `tests/makefile_tests.rs` integration tests covering loading scripts from a Makefile on disk and listing parsed targets.